### PR TITLE
Add license option on folder creation

### DIFF
--- a/resources/views/livewire/admin/folder/folder-create.blade.php
+++ b/resources/views/livewire/admin/folder/folder-create.blade.php
@@ -8,6 +8,12 @@
             <p>{{ session('success') }}</p>
         </div>
     @endif
+    @if (session()->has('error'))
+        <div class="bg-red-100 border-l-4 border-red-500 text-red-700 p-4 rounded-md shadow-sm dark:bg-red-700 dark:text-red-100" role="alert">
+            <p class="font-bold">Erreur</p>
+            <p>{{ session('error') }}</p>
+        </div>
+    @endif
     {{-- Progress Bar --}}
     <div class="mb-8">
         <div class="h-2 bg-gray-200 dark:bg-gray-700 rounded-full">
@@ -24,12 +30,24 @@
             <h3 class="text-lg font-semibold text-gray-700 dark:text-gray-200 border-b pb-2 mb-6 border-gray-300 dark:border-gray-600">Étape 1: Informations de Base</h3>
             <div class="space-y-4">
              <x-forms.select label="Client (Société)" model="company_id" :options="$companies" optionLabel="name" optionValue="id" required placeholder="Sélectionner un client" />
+             <x-forms.select label="Type de Dossier" model="dossier_type" :options="\App\Enums\DossierType::options()" optionLabel="label" optionValue="value" required />
                 <x-forms.input label="Numéro de Dossier" model="folder_number" required />
                  <x-forms.input label="Numéro de la facture" model="invoice_number" required />
                 <x-forms.input label="Date du Dossier" model="folder_date" type="date" required />
                 <x-forms.select label="Fournisseur" model="supplier_id" :options="$suppliers" optionLabel="name" optionValue="id" placeholder="Sélectionner un fournisseur" />
                 <x-forms.input label="Nature Marchandise" model="goods_type" required />
                 <x-forms.textarea label="Description Générale" model="description" rows="3" />
+            </div>
+        </div>
+        @endif
+
+        {{-- Step 4: Licence Selection --}}
+        @if ($dossier_type === 'avec' && $currentStep === 4)
+        <div class="p-4 border border-gray-200 dark:border-gray-700 rounded-lg shadow-sm animate-fadeIn">
+            <h3 class="text-lg font-semibold text-gray-700 dark:text-gray-200 border-b pb-2 mb-6 border-gray-300 dark:border-gray-600">Étape 4: Licence</h3>
+            <div class="space-y-4">
+                <x-forms.select label="Licence" model="license_id" :options="$licenses" optionLabel="license_number" optionValue="id" placeholder="Sélectionner une licence" />
+                <x-forms.input label="Code Licence" model="license_code" />
             </div>
         </div>
         @endif

--- a/tests/Feature/Admin/FolderLicenseUsageTest.php
+++ b/tests/Feature/Admin/FolderLicenseUsageTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Enums\DossierType;
+use App\Livewire\Admin\Folder\FolderCreate;
+use App\Models\Company;
+use App\Models\CustomsOffice;
+use App\Models\DeclarationType;
+use App\Models\Licence;
+use App\Models\Location;
+use App\Models\Transporter;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class FolderLicenseUsageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function folder_creation_with_license_updates_license_counters(): void
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $company = Company::create(['name' => 'Comp', 'acronym' => 'CMP']);
+        $transporter = Transporter::create(['name' => 'Trans']);
+        $location = Location::create(['name' => 'Loc']);
+        $customsOffice = CustomsOffice::create(['name' => 'Office']);
+        $declarationType = DeclarationType::create(['name' => 'Type']);
+
+        $license = Licence::create([
+            'license_number' => 'LIC-100',
+            'license_type' => 'Import',
+            'company_id' => $company->id,
+            'max_folders' => 1,
+            'remaining_folders' => 1,
+            'initial_weight' => 100,
+            'remaining_weight' => 100,
+            'initial_fob_amount' => 200,
+            'remaining_fob_amount' => 200,
+            'quantity_total' => 10,
+            'remaining_quantity' => 10,
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(FolderCreate::class)
+            ->set('company_id', $company->id)
+            ->set('dossier_type', DossierType::AVEC->value)
+            ->set('license_id', $license->id)
+            ->set('license_code', 'LIC-100')
+            ->set('folder_number', 'TEST-001')
+            ->set('invoice_number', 'INV-001')
+            ->set('folder_date', now()->toDateString())
+            ->set('goods_type', 'Goods')
+            ->set('transporter_id', $transporter->id)
+            ->set('transport_mode', 'Route')
+            ->set('weight', 50)
+            ->set('quantity', 2)
+            ->set('fob_amount', 20)
+            ->call('save')
+            ->assertHasNoErrors();
+
+        $this->assertDatabaseHas('folders', [
+            'folder_number' => 'TEST-001',
+            'license_id' => $license->id,
+        ]);
+
+        $license->refresh();
+        $this->assertEquals(0, $license->remaining_folders);
+        $this->assertEquals(50, $license->remaining_weight);
+        $this->assertEquals(180, $license->remaining_fob_amount);
+        $this->assertEquals(8, $license->remaining_quantity);
+    }
+}


### PR DESCRIPTION
## Summary
- support folder creation with license
- show license step in creation form
- track license deductions on folder save
- test license deductions

## Testing
- `vendor/bin/phpunit --filter FolderLicenseUsageTest.php` *(fails: `vendor/bin/phpunit: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_684428d7407c8320b40c98c08f9f4b9f