### PR TITLE
Validate invoice item descriptions

### DIFF
--- a/app/Services/Invoice/GlobalInvoiceService.php
+++ b/app/Services/Invoice/GlobalInvoiceService.php
@@ -110,6 +110,12 @@ class GlobalInvoiceService
 
             foreach ($invoices as $invoice) {
                 foreach ($invoice->items as $item) {
+                    if (is_null($item->description) || trim($item->description) === '') {
+                        throw ValidationException::withMessages([
+                            'items' => "L'article {$item->id} n'a pas de description",
+                        ]);
+                    }
+
                     $itemsToCopy[] = [
                         'description' => $item->description,
                         'quantity' => $item->quantity,

--- a/tests/Feature/Admin/GlobalInvoiceManagementTest.php
+++ b/tests/Feature/Admin/GlobalInvoiceManagementTest.php
@@ -239,7 +239,7 @@ class GlobalInvoiceManagementTest extends TestCase
             'unit_price' => 10.00,
             'total_price' => 10.00,
         ]);
-        InvoiceItem::factory()->for($invoiceWithMissingDesc)->create([
+        $missingItem = InvoiceItem::factory()->for($invoiceWithMissingDesc)->create([
             'description' => null, // Description manquante
             'quantity' => 2,
             'unit_price' => 5.00,
@@ -262,7 +262,9 @@ class GlobalInvoiceManagementTest extends TestCase
 
         // Vérifie qu'un message d'erreur est présent dans la session
         Livewire::test(InvoiceIndex::class)
-            ->assertSessionHas('error');
+            ->assertSessionHas('error', function ($message) use ($missingItem) {
+                return str_contains($message, "L'article {$missingItem->id} n'a pas de description");
+            });
 
         // Vérifie que la facture originale n'a pas été modifiée
         $originalInvoice = $invoiceWithMissingDesc->fresh();


### PR DESCRIPTION
## Summary
- validate invoice item descriptions when generating a global invoice
- test session error message when an invoice item lacks description

## Testing
- `./vendor/bin/pest` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6845c7fe1960832084eadcb9dd0824ec