### PR TITLE
Fix global invoice item aggregation

### DIFF
--- a/app/Models/GlobalInvoiceItem.php
+++ b/app/Models/GlobalInvoiceItem.php
@@ -19,6 +19,10 @@ class GlobalInvoiceItem extends Model
         'original_item_ids',
     ];
 
+    protected $casts = [
+        'original_item_ids' => 'array',
+    ];
+
     /**
      * Get the global invoice that owns the item.
      */

--- a/database/factories/GlobalInvoiceItemFactory.php
+++ b/database/factories/GlobalInvoiceItemFactory.php
@@ -4,7 +4,6 @@ namespace Database\Factories;
 
 use App\Models\GlobalInvoiceItem;
 use App\Models\GlobalInvoice;
-use App\Models\Invoice; // Assuming a global invoice item links to a regular invoice
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 class GlobalInvoiceItemFactory extends Factory
@@ -15,14 +14,13 @@ class GlobalInvoiceItemFactory extends Factory
     {
         return [
             'global_invoice_id' => GlobalInvoice::factory(),
-            'invoice_id' => Invoice::factory(), // Link to an individual invoice
             'description' => $this->faker->sentence,
-            'quantity' => $this->faker->numberBetween(1, 10),
+            'quantity' => $this->faker->numberBetween(1, 5),
             'unit_price' => $this->faker->randomFloat(2, 10, 500),
-            'total_amount' => function (array $attributes) {
+            'total_price' => function (array $attributes) {
                 return $attributes['quantity'] * $attributes['unit_price'];
             },
-            // Add other fields as necessary based on your GlobalInvoiceItem migration
+            'original_item_ids' => [],
             'created_at' => now(),
             'updated_at' => now(),
         ];


### PR DESCRIPTION
## Summary
- group global invoice items by label when creating a global invoice
- cast `original_item_ids` as array
- align global invoice item factory with schema

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6845c9fe41f88320823ebcefb794a497