### PR TITLE
Enable invoice PDF download

### DIFF
--- a/app/Livewire/Admin/Invoices/ShowInvoice.php
+++ b/app/Livewire/Admin/Invoices/ShowInvoice.php
@@ -24,6 +24,18 @@ class ShowInvoice extends Component
     /**
      * Téléchargement de la facture au format PDF.
      */
+
+    public function downloadPdf(): StreamedResponse
+    {
+        $filename = 'Facture_' . $this->invoice->invoice_number . '.pdf';
+
+        $pdf = Pdf::loadView('pdf.invoice', ['invoice' => $this->invoice]);
+
+        return response()->streamDownload(
+            fn () => print($pdf->output()),
+            $filename
+        );
+    }
     
 
     /**

--- a/tests/Feature/Admin/InvoicePdfDownloadTest.php
+++ b/tests/Feature/Admin/InvoicePdfDownloadTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Models\User;
+use App\Models\Company;
+use App\Models\Invoice;
+use App\Livewire\Admin\Invoices\ShowInvoice as ShowInvoiceComponent;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class InvoicePdfDownloadTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $user;
+    protected Company $company;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+        $this->actingAs($this->user);
+        $this->company = Company::factory()->create();
+    }
+
+    /** @test */
+    public function test_can_download_invoice_pdf(): void
+    {
+        $invoice = Invoice::factory()->for($this->company)->create();
+
+        $response = Livewire::test(ShowInvoiceComponent::class, ['invoice' => $invoice])
+            ->call('downloadPdf');
+
+        $response->assertStatus(200);
+        $response->assertHeader('Content-Type', 'application/pdf');
+        $response->assertHeader('Content-Disposition', 'attachment; filename="Facture_' . $invoice->invoice_number . '.pdf"');
+    }
+}


### PR DESCRIPTION
## Summary
- add `downloadPdf` method to `ShowInvoice` Livewire component
- cover PDF download via new feature test

## Testing
- `phpunit` *(fails: PHP not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6845d026fe588320a45b8a69f2148bc3