### PR TITLE
Add invoice currency fields to mass assignment

### DIFF
--- a/app/Models/Invoice.php
+++ b/app/Models/Invoice.php
@@ -23,6 +23,8 @@ class Invoice extends Model
         'invoice_date',
         'payment_mode',
         'total_usd',
+        'currency_id',
+        'exchange_rate',
         'global_invoice_id',
         'status',
         'folder_id', // Ajout de folder_id


### PR DESCRIPTION
## Summary
- make `currency_id` and `exchange_rate` mass assignable for invoices

## Testing
- `php artisan test` *(fails: php command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845e2e13e148320bb0ca1c6d3906a94