### PR TITLE
Fix invoice number generation with locking

### DIFF
--- a/app/Livewire/Admin/Invoices/GenerateInvoice.php
+++ b/app/Livewire/Admin/Invoices/GenerateInvoice.php
@@ -264,7 +264,6 @@ class GenerateInvoice extends Component
         $this->items = $processedItems; // Mettre à jour les items avec les montants recalculés
         $this->total_usd = $totalUsdFromItems;
         $invoiceData = [
-            'invoice_number' => 'MDBKCCGL' . str_pad((Invoice::max('id') ?? 0) + 1, 6, '0', STR_PAD_LEFT),
             'company_id' => $this->company_id,
             'invoice_date' => Carbon::parse($this->invoice_date),
             'product' => $this->product,
@@ -284,6 +283,8 @@ class GenerateInvoice extends Component
         ];
 
         $invoice = DB::transaction(function () use ($invoiceData) {
+            $maxId = DB::table('invoices')->lockForUpdate()->max('id') ?? 0;
+            $invoiceData['invoice_number'] = 'MDBKCCGL' . str_pad($maxId + 1, 6, '0', STR_PAD_LEFT);
             $invoice = Invoice::create($invoiceData);
 
             foreach ($this->items as $itemData) {


### PR DESCRIPTION
## Summary
- ensure invoice numbers are generated inside a DB lock

## Testing
- `php artisan test --parallel` *(fails: `php: command not found`)*
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6845e9b6c7348320a7f01e2406fe9445