### PR TITLE
Implement global invoice deletion flow

### DIFF
--- a/app/Livewire/Admin/Invoices/GlobalInvoiceIndex.php
+++ b/app/Livewire/Admin/Invoices/GlobalInvoiceIndex.php
@@ -3,6 +3,7 @@
 namespace App\Livewire\Admin\Invoices;
 
 use App\Models\GlobalInvoice;
+use Illuminate\Support\Facades\DB;
 use Livewire\Component;
 use Livewire\WithPagination;
 
@@ -16,6 +17,23 @@ class GlobalInvoiceIndex extends Component
     public function updatingSearch(): void
     {
         $this->resetPage();
+    }
+
+    public function deleteGlobalInvoice(int $id): void
+    {
+        DB::transaction(function () use ($id) {
+            $globalInvoice = GlobalInvoice::with('invoices')->findOrFail($id);
+
+            foreach ($globalInvoice->invoices as $invoice) {
+                $invoice->global_invoice_id = null;
+                $invoice->status = 'pending';
+                $invoice->save();
+            }
+
+            $globalInvoice->delete();
+        });
+
+        session()->flash('success', 'Facture globale supprimée avec succès.');
     }
 
     public function render()

--- a/resources/views/livewire/admin/invoices/global-invoice-index.blade.php
+++ b/resources/views/livewire/admin/invoices/global-invoice-index.blade.php
@@ -50,6 +50,11 @@
                                 <a href="{{ route('admin.global-invoices.show', $globalInvoice->id) }}" class="text-blue-600 hover:text-blue-900 font-medium">
                                     Voir Détails
                                 </a>
+                                <button wire:click="deleteGlobalInvoice({{ $globalInvoice->id }})"
+                                        onclick="return confirm('Confirmer la suppression de cette facture globale ?')"
+                                        class="text-red-600 hover:underline text-sm cursor-pointer">
+                                    🗑 Supprimer
+                                </button>
                                 {{-- Possibilité d'ajouter d'autres actions comme "Télécharger PDF" directement ici --}}
                             </td>
                         </tr>

--- a/tests/Feature/Admin/GlobalInvoiceManagementTest.php
+++ b/tests/Feature/Admin/GlobalInvoiceManagementTest.php
@@ -271,4 +271,22 @@ class GlobalInvoiceManagementTest extends TestCase
         $this->assertNull($originalInvoice->global_invoice_id);
         $this->assertEquals('pending', $originalInvoice->status);
     }
+
+    /** @test */
+    public function test_can_delete_global_invoice(): void
+    {
+        $globalInvoice = GlobalInvoice::factory()->for($this->company)->create();
+        $invoice = Invoice::factory()->for($this->company)->create([
+            'global_invoice_id' => $globalInvoice->id,
+            'status' => 'grouped_in_global_invoice',
+        ]);
+
+        Livewire::test(GlobalInvoiceIndexComponent::class)
+            ->call('deleteGlobalInvoice', $globalInvoice->id);
+
+        $this->assertDatabaseMissing('global_invoices', ['id' => $globalInvoice->id]);
+        $invoice->refresh();
+        $this->assertNull($invoice->global_invoice_id);
+        $this->assertEquals('pending', $invoice->status);
+    }
 }


### PR DESCRIPTION
## Summary
- allow admin to delete a global invoice and reset linked invoices
- show delete button in global invoice list
- test deletion behaviour

## Testing
- `./vendor/bin/phpunit --stop-on-failure` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846bf70b75c8320a9c347b120b7b175