### PR TITLE
Add freight and currency fields to folder creation

### DIFF
--- a/app/Models/Folder.php
+++ b/app/Models/Folder.php
@@ -7,6 +7,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Casts\Attribute;
+use App\Models\Currency;
 use Kyslik\ColumnSortable\Sortable;
 
 class Folder extends Model
@@ -38,7 +39,9 @@ class Folder extends Model
         'quantity',
         'fob_amount',
         'insurance_amount',
+        'freight_amount',
         'cif_amount',
+        'currency_id',
         'arrival_border_date',
         'description',
         'dossier_type',
@@ -55,6 +58,7 @@ class Folder extends Model
         'quantity' => 'float',
         'fob_amount' => 'float',
         'insurance_amount' => 'float',
+        'freight_amount' => 'float',
         'cif_amount' => 'float',
         'dossier_type' => DossierType::class,
     ];
@@ -103,6 +107,11 @@ class Folder extends Model
     public function files()
     {
         return $this->hasMany(\App\Models\FolderFile::class);
+    }
+
+    public function currency()
+    {
+        return $this->belongsTo(Currency::class);
     }
 
     public function license()

--- a/app/Services/Folder/FolderService.php
+++ b/app/Services/Folder/FolderService.php
@@ -49,7 +49,8 @@ class FolderService
         return DB::transaction(function () use ($data) {
             $fob = floatval($data['fob_amount'] ?? 0);
             $insurance = floatval($data['insurance_amount'] ?? 0);
-            $data['cif_amount'] = $fob + $insurance;
+            $freight = floatval($data['freight_amount'] ?? 0);
+            $data['cif_amount'] = $fob + $insurance + $freight;
 
             $folder = Folder::create($data);
 
@@ -90,7 +91,9 @@ class FolderService
             'weight' => $data['weight'] ?? 0,
             'fob_amount' => $data['fob_amount'] ?? 0,
             'insurance_amount' => $data['insurance_amount'] ?? 0,
-            'cif_amount' => $data['cif_amount'] ?? 0,
+            'freight_amount' => $data['freight_amount'] ?? 0,
+            'currency_id' => $data['currency_id'] ?? null,
+            'cif_amount' => ($data['fob_amount'] ?? 0) + ($data['insurance_amount'] ?? 0) + ($data['freight_amount'] ?? 0),
             'arrival_border_date' => $data['arrival_border_date'] ?? null,
             'description' => $data['description'] ?? null,
         ]);

--- a/database/factories/FolderFactory.php
+++ b/database/factories/FolderFactory.php
@@ -11,6 +11,7 @@ use App\Models\Supplier;
 use App\Models\CustomsOffice;
 use App\Models\DeclarationType;
 use App\Models\Licence;
+use App\Models\Currency;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 class FolderFactory extends Factory
@@ -42,7 +43,9 @@ class FolderFactory extends Factory
             'quantity' => $this->faker->optional()->numberBetween(1, 100),
             'fob_amount' => $this->faker->optional()->randomFloat(2, 1000, 100000),
             'insurance_amount' => $this->faker->optional()->randomFloat(2, 100, 5000),
+            'freight_amount' => $this->faker->optional()->randomFloat(2, 100, 5000),
             'cif_amount' => $this->faker->optional()->randomFloat(2, 1100, 105000),
+            'currency_id' => Currency::factory(),
             'arrival_border_date' => $this->faker->optional()->date(),
             'description' => $this->faker->paragraph,
             'dossier_type' => $this->faker->randomElement(['sans', 'avec_licence']), // Example types

--- a/database/migrations/2025_07_01_000000_add_freight_and_currency_to_folders_table.php
+++ b/database/migrations/2025_07_01_000000_add_freight_and_currency_to_folders_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('folders', function (Blueprint $table) {
+            $table->decimal('freight_amount', 15, 2)->nullable()->after('insurance_amount');
+            $table->foreignId('currency_id')->nullable()->after('freight_amount')
+                ->constrained('currencies')->nullOnDelete();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('folders', function (Blueprint $table) {
+            $table->dropForeign(['currency_id']);
+            $table->dropColumn(['freight_amount', 'currency_id']);
+        });
+    }
+};

--- a/resources/views/livewire/admin/folder/folder-create.blade.php
+++ b/resources/views/livewire/admin/folder/folder-create.blade.php
@@ -34,6 +34,7 @@
                 <x-forms.input label="Numéro de Dossier" model="folder_number" required />
                 <x-forms.input label="Numéro de la facture" model="invoice_number" required />
                 <x-forms.input label="Date du Dossier" model="folder_date" type="date" required />
+                <x-forms.select label="Devise" model="currency_id" :options="$currencies" optionLabel="code" optionValue="id" required />
                 <x-forms.select label="Fournisseur" model="supplier_id" :options="$suppliers" optionLabel="name" optionValue="id" placeholder="Sélectionner un fournisseur" />
                 <x-forms.select label="Nature Marchandise" model="goods_type" :options="$merchandiseTypes" optionLabel="name" optionValue="name" required placeholder="Sélectionner un type de marchandise" />
                 <x-forms.textarea label="Description Générale" model="description" rows="3" />
@@ -61,6 +62,7 @@
                 <x-forms.input label="Quantité de Marchandise" model="quantity" type="number" step="0.01" />
                 <x-forms.input label="Montant FOB" model="fob_amount" type="number" step="0.01" />
                 <x-forms.input label="Montant Assurance" model="insurance_amount" type="number" step="0.01" />
+                <x-forms.input label="Fret" model="freight_amount" type="number" step="0.01" />
                 <x-forms.input label="Montant CIF" model="cif_amount" type="number" step="0.01" />
             </div>
         </div>


### PR DESCRIPTION
## Summary
- allow specifying `currency_id` and `freight_amount` when creating folders
- compute CIF from FOB, insurance and freight
- expose currency relation on `Folder`
- scaffold migration and factory updates

## Testing
- `php` was not available so syntax was not checked

------
https://chatgpt.com/codex/tasks/task_e_684737455878832083be50426ac6ba6d