### PR TITLE
Add CIF auto-calculation

### DIFF
--- a/app/Livewire/Admin/Folder/FolderCreate.php
+++ b/app/Livewire/Admin/Folder/FolderCreate.php
@@ -105,6 +105,18 @@ class FolderCreate extends Component
         }
     }
 
+    public function updated($property)
+    {
+        if (in_array($property, ['fob_amount', 'insurance_amount', 'freight_amount'])) {
+            $this->calculateCif();
+        }
+    }
+
+    public function calculateCif()
+    {
+        $this->cif_amount = (float)$this->fob_amount + (float)$this->insurance_amount + (float)$this->freight_amount;
+    }
+
     public function generateFolderNumber(string $acronym)
     {
         $year = now()->format('y');

--- a/resources/views/livewire/admin/folder/folder-create.blade.php
+++ b/resources/views/livewire/admin/folder/folder-create.blade.php
@@ -63,7 +63,7 @@
                 <x-forms.input label="Montant FOB" model="fob_amount" type="number" step="0.01" />
                 <x-forms.input label="Montant Assurance" model="insurance_amount" type="number" step="0.01" />
                 <x-forms.input label="Fret" model="freight_amount" type="number" step="0.01" />
-                <x-forms.input label="Montant CIF" model="cif_amount" type="number" step="0.01" />
+                <x-forms.input label="Montant CIF" model="cif_amount" type="number" step="0.01" disabled />
             </div>
         </div>
         @endif

--- a/tests/Feature/Livewire/Admin/Folder/FolderCifCalculationTest.php
+++ b/tests/Feature/Livewire/Admin/Folder/FolderCifCalculationTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Tests\Feature\Livewire\Admin\Folder;
+
+use App\Livewire\Admin\Folder\FolderCreate;
+use App\Models\User;
+use App\Models\Currency;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class FolderCifCalculationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_cif_is_calculated_when_amounts_change(): void
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        Currency::factory()->create(['code' => 'USD']);
+
+        Livewire::test(FolderCreate::class)
+            ->set('fob_amount', 100)
+            ->assertSet('cif_amount', 100.0)
+            ->set('insurance_amount', 50)
+            ->assertSet('cif_amount', 150.0)
+            ->set('freight_amount', 25)
+            ->assertSet('cif_amount', 175.0);
+    }
+}


### PR DESCRIPTION
## Summary
- compute CIF amount automatically in FolderCreate component
- disable editing of the CIF field in the create folder form
- test CIF calculation when amounts change

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_684739de0cdc8320b458cfc43a104c90