### PR TITLE
Add missing category column migration

### DIFF
--- a/database/migrations/2025_08_01_000001_add_category_to_global_invoice_items_table.php
+++ b/database/migrations/2025_08_01_000001_add_category_to_global_invoice_items_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('global_invoice_items', function (Blueprint $table) {
+            if (!Schema::hasColumn('global_invoice_items', 'category')) {
+                $table->enum('category', ['import_tax', 'agency_fee', 'extra_fee'])
+                    ->default('import_tax')
+                    ->after('global_invoice_id');
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('global_invoice_items', function (Blueprint $table) {
+            if (Schema::hasColumn('global_invoice_items', 'category')) {
+                $table->dropColumn('category');
+            }
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- add new migration to add `category` column to `global_invoice_items`

## Testing
- `php artisan test` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68482a1ec214832096c1261a100148a8