### PR TITLE
Fix company field references in invoice views

### DIFF
--- a/resources/views/livewire/admin/invoices/show-invoice.blade.php
+++ b/resources/views/livewire/admin/invoices/show-invoice.blade.php
@@ -15,8 +15,8 @@
             <p class="font-semibold text-gray-800">{{ $invoice->company->name }}</p>
             <p class="text-xs text-gray-500">{{ $invoice->company->email }}</p>
             <p class="text-xs text-gray-500">{{ $invoice->company->phone_number }}</p>
-            <p class="text-xs text-gray-500">RCCM : {{ $invoice->company->rccm }}</p>
-            <p class="text-xs text-gray-500">N° Impôt : {{ $invoice->company->tax_number }}</p>
+            <p class="text-xs text-gray-500">RCCM : {{ $invoice->company->commercial_register }}</p>
+            <p class="text-xs text-gray-500">N° Impôt : {{ $invoice->company->tax_id }}</p>
         </div>
     </div>
 

--- a/resources/views/pdf/invoice.blade.php
+++ b/resources/views/pdf/invoice.blade.php
@@ -75,11 +75,10 @@
             <td>
                 <strong>Client :</strong><br>
                 {{ $invoice->company->name }}<br>
-                {{ $invoice->company->address ?? 'Avenue Kasa-Vubu, Immeuble M. de la Paix' }}<br>
-                RCCM : {{ $invoice->company->rccm ?? 'CD/KZ/KCM/14-B-020' }}<br>
-                TAX N° : {{ $invoice->company->tax_number ?? 'A07040104' }}<br>
-                VAT N° : {{ $invoice->company->vat_number ?? '0479/DGI/DGE/DIG/MB/TVA/2011' }}<br>
-                ID NAT : {{ $invoice->company->id_nat ?? '14-B0500-N455970' }}
+                {{ $invoice->company->physical_address ?? 'Avenue Kasa-Vubu, Immeuble M. de la Paix' }}<br>
+                RCCM : {{ $invoice->company->commercial_register ?? 'CD/KZ/KCM/14-B-020' }}<br>
+                TAX N° : {{ $invoice->company->tax_id ?? 'A07040104' }}<br>
+                ID NAT : {{ $invoice->company->national_identification ?? '14-B0500-N455970' }}
             </td>
             <td class="right">
                 Lubumbashi le {{ Carbon::parse($invoice->invoice_date)->format('d/m/Y') }}<br><br>


### PR DESCRIPTION
## Summary
- update invoice view to use `commercial_register` and `tax_id`
- update invoice PDF template with new company field names and remove outdated VAT line

## Testing
- `php artisan test` *(fails: `php` not found)*
- `npm test --silent` *(no tests defined)*

------
https://chatgpt.com/codex/tasks/task_e_6848354df01083209b5dda8009c8960e