### PR TITLE
Implement soft delete support for invoices

### DIFF
--- a/app/Livewire/Admin/Invoices/GlobalInvoiceIndex.php
+++ b/app/Livewire/Admin/Invoices/GlobalInvoiceIndex.php
@@ -12,6 +12,7 @@ class GlobalInvoiceIndex extends Component
     use WithPagination;
 
     public string $search = '';
+    public bool $showTrashed = false;
     protected $paginationTheme = 'bootstrap'; // Ou le thème de votre choix si configuré
 
     public function updatingSearch(): void
@@ -45,6 +46,7 @@ class GlobalInvoiceIndex extends Component
                         $companyQuery->where('name', 'like', '%' . $this->search . '%');
                     });
             })
+            ->when($this->showTrashed, fn($q) => $q->onlyTrashed())
             ->latest() // Ou orderBy('issue_date', 'desc')
             ->paginate(15);
 

--- a/app/Livewire/Admin/Invoices/InvoiceIndex.php
+++ b/app/Livewire/Admin/Invoices/InvoiceIndex.php
@@ -17,6 +17,7 @@ class InvoiceIndex extends Component
     use WithPagination;
 
     public $search = '';
+    public bool $showTrashed = false;
     public array $selectedInvoices = [];
     public ?int $companyIdForGlobalInvoice = null;
 
@@ -131,6 +132,7 @@ class InvoiceIndex extends Component
                 $query->where('invoice_number', 'like', "%{$this->search}%")
                     ->orWhereHas('company', fn($q) => $q->where('name', 'like', "%{$this->search}%"));
             })
+            ->when($this->showTrashed, fn($q) => $q->onlyTrashed())
             ->latest()
             ->paginate(10);
 

--- a/app/Livewire/Admin/Invoices/InvoiceTrash.php
+++ b/app/Livewire/Admin/Invoices/InvoiceTrash.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Livewire\Admin\Invoices;
+
+use Livewire\Component;
+use Livewire\WithPagination;
+use App\Models\Invoice;
+use App\Models\GlobalInvoice;
+
+class InvoiceTrash extends Component
+{
+    use WithPagination;
+
+    public function restoreInvoice(int $id): void
+    {
+        $invoice = Invoice::onlyTrashed()->findOrFail($id);
+        $invoice->restore();
+        session()->flash('success', 'Facture restaurée avec succès.');
+    }
+
+    public function restoreGlobalInvoice(int $id): void
+    {
+        $globalInvoice = GlobalInvoice::onlyTrashed()->findOrFail($id);
+        $globalInvoice->restore();
+        session()->flash('success', 'Facture globale restaurée avec succès.');
+    }
+
+    public function render()
+    {
+        return view('livewire.admin.invoices.invoice-trash', [
+            'trashedInvoices' => Invoice::onlyTrashed()->with('company')->paginate(10),
+            'trashedGlobalInvoices' => GlobalInvoice::onlyTrashed()->with('company')->paginate(10),
+        ]);
+    }
+}

--- a/app/Models/GlobalInvoice.php
+++ b/app/Models/GlobalInvoice.php
@@ -4,12 +4,13 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class GlobalInvoice extends Model
 {
-    use HasFactory;
+    use HasFactory, SoftDeletes;
 
     protected $fillable = [
         'global_invoice_number',

--- a/app/Models/Invoice.php
+++ b/app/Models/Invoice.php
@@ -4,11 +4,11 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
 class Invoice extends Model
 {
-    //
-    use HasFactory;
+    use HasFactory, SoftDeletes;
 
     protected $fillable = [
         'invoice_number',

--- a/database/migrations/2025_09_01_000001_add_deleted_at_to_invoices_table.php
+++ b/database/migrations/2025_09_01_000001_add_deleted_at_to_invoices_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('invoices', function (Blueprint $table) {
+            $table->softDeletes();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('invoices', function (Blueprint $table) {
+            $table->dropSoftDeletes();
+        });
+    }
+};

--- a/database/migrations/2025_09_01_000002_add_deleted_at_to_global_invoices_table.php
+++ b/database/migrations/2025_09_01_000002_add_deleted_at_to_global_invoices_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('global_invoices', function (Blueprint $table) {
+            $table->softDeletes();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('global_invoices', function (Blueprint $table) {
+            $table->dropSoftDeletes();
+        });
+    }
+};

--- a/resources/views/livewire/admin/invoices/invoice-trash.blade.php
+++ b/resources/views/livewire/admin/invoices/invoice-trash.blade.php
@@ -1,0 +1,63 @@
+<div class="max-w-6xl mx-auto p-6 bg-white rounded-xl shadow space-y-6">
+    <h2 class="text-xl font-bold">🗑 Factures Supprimées</h2>
+
+    @if (session()->has('success'))
+        <div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative" role="alert">
+            <span class="block sm:inline">{{ session('success') }}</span>
+        </div>
+    @endif
+
+    <h3 class="font-semibold mt-4">Factures Individuelles</h3>
+    <table class="w-full border mt-2 text-sm">
+        <thead class="bg-gray-100">
+            <tr>
+                <th class="border px-2 py-1">Numéro</th>
+                <th class="border px-2 py-1">Client</th>
+                <th class="border px-2 py-1">Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            @forelse ($trashedInvoices as $invoice)
+                <tr>
+                    <td class="border px-2 py-1">{{ $invoice->invoice_number }}</td>
+                    <td class="border px-2 py-1">{{ $invoice->company?->name }}</td>
+                    <td class="border px-2 py-1">
+                        <button wire:click="restoreInvoice({{ $invoice->id }})" class="text-blue-600 hover:underline">Restaurer</button>
+                    </td>
+                </tr>
+            @empty
+                <tr>
+                    <td colspan="3" class="text-center py-4 text-gray-500">Aucune facture.</td>
+                </tr>
+            @endforelse
+        </tbody>
+    </table>
+    {{ $trashedInvoices->links() }}
+
+    <h3 class="font-semibold mt-8">Factures Globales</h3>
+    <table class="w-full border mt-2 text-sm">
+        <thead class="bg-gray-100">
+            <tr>
+                <th class="border px-2 py-1">Numéro</th>
+                <th class="border px-2 py-1">Client</th>
+                <th class="border px-2 py-1">Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            @forelse ($trashedGlobalInvoices as $global)
+                <tr>
+                    <td class="border px-2 py-1">{{ $global->global_invoice_number }}</td>
+                    <td class="border px-2 py-1">{{ $global->company?->name }}</td>
+                    <td class="border px-2 py-1">
+                        <button wire:click="restoreGlobalInvoice({{ $global->id }})" class="text-blue-600 hover:underline">Restaurer</button>
+                    </td>
+                </tr>
+            @empty
+                <tr>
+                    <td colspan="3" class="text-center py-4 text-gray-500">Aucune facture globale.</td>
+                </tr>
+            @endforelse
+        </tbody>
+    </table>
+    {{ $trashedGlobalInvoices->links() }}
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -30,6 +30,7 @@ use App\Livewire\Admin\Invoices\ShowInvoice;
 use App\Livewire\Admin\Invoices\GenerateInvoice;
 use App\Livewire\Admin\Invoices\InvoiceIndex;
 use App\Livewire\Admin\Invoices\UpdateInvoice;
+use App\Livewire\Admin\Invoices\InvoiceTrash;
 use App\Livewire\Admin\Invoices\GlobalInvoiceIndex; // Ajout pour GlobalInvoiceIndex
 use App\Livewire\Admin\Invoices\GlobalInvoiceShow;  // Ajout pour GlobalInvoiceShow
 
@@ -142,7 +143,8 @@ Route::middleware('auth')->group(function () {
         Route::get('/download/{invoice}', [ShowInvoice::class, 'downloadPdf'])->name('download');
         Route::get('/index', InvoiceIndex::class)->name('index');
         Route::get('/invoices/{invoice}/edit', UpdateInvoice::class)->name('invoices.edit');
-        
+        Route::get('/trash', InvoiceTrash::class)->name('trash');
+
     });
 
     Route::prefix('currency')->name('currency.')->group(function () {

--- a/tests/Feature/Admin/InvoiceSoftDeleteTest.php
+++ b/tests/Feature/Admin/InvoiceSoftDeleteTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Models\User;
+use App\Models\Company;
+use App\Models\Invoice;
+use App\Livewire\Admin\Invoices\InvoiceIndex;
+use App\Livewire\Admin\Invoices\InvoiceTrash;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class InvoiceSoftDeleteTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $user;
+    protected Company $company;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+        $this->actingAs($this->user);
+        $this->company = Company::factory()->create();
+    }
+
+    /** @test */
+    public function test_invoice_soft_delete_and_restore(): void
+    {
+        $invoice = Invoice::factory()->for($this->company)->create();
+
+        Livewire::test(InvoiceIndex::class)
+            ->call('deleteInvoice', $invoice->id);
+
+        $this->assertSoftDeleted('invoices', ['id' => $invoice->id]);
+
+        Livewire::test(InvoiceTrash::class)
+            ->call('restoreInvoice', $invoice->id);
+
+        $this->assertDatabaseHas('invoices', [
+            'id' => $invoice->id,
+            'deleted_at' => null,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- enable SoftDeletes on `Invoice` and `GlobalInvoice`
- add migrations for `deleted_at`
- include trashed filtering in invoice components
- implement recycle bin component with restore actions
- wire up new trash route
- adjust tests for soft deletion behaviour

## Testing
- `composer test` *(fails: `composer: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68483e51dc108320a212be9fbad927c4