### PR TITLE
Add Account Settings controller

### DIFF
--- a/app/Http/Controllers/AccountSettingsController.php
+++ b/app/Http/Controllers/AccountSettingsController.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Redirect;
+use Illuminate\View\View;
+
+class AccountSettingsController extends Controller
+{
+    public function edit(Request $request): View
+    {
+        return view('account.settings', [
+            'user' => $request->user(),
+        ]);
+    }
+
+    public function update(Request $request): RedirectResponse
+    {
+        $data = $request->validate([
+            'notifications_enabled' => ['required', 'boolean'],
+            'language' => ['required', 'string', 'max:10'],
+        ]);
+
+        $user = $request->user();
+        $user->notifications_enabled = $data['notifications_enabled'];
+        $user->language = $data['language'];
+        $user->save();
+
+        return Redirect::route('account.settings')->with('status', 'settings-updated');
+    }
+}

--- a/database/migrations/2025_09_02_000000_add_preferences_to_users_table.php
+++ b/database/migrations/2025_09_02_000000_add_preferences_to_users_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->boolean('notifications_enabled')->default(true);
+            $table->string('language', 10)->default('en');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn(['notifications_enabled', 'language']);
+        });
+    }
+};

--- a/resources/views/account/settings.blade.php
+++ b/resources/views/account/settings.blade.php
@@ -9,7 +9,34 @@
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 space-y-6">
             <div class="p-4 sm:p-8 bg-white dark:bg-gray-800 shadow sm:rounded-lg">
                 <div class="max-w-xl">
-                    <p class="text-gray-500">{{ __('Account settings page.') }}</p>
+                    <form method="post" action="{{ route('account.settings.update') }}" class="space-y-6">
+                        @csrf
+                        @method('patch')
+
+                        <div>
+                            <x-input-label for="notifications_enabled" :value="__('Email Notifications')" />
+                            <input id="notifications_enabled" name="notifications_enabled" type="checkbox" value="1" class="mt-1" {{ old('notifications_enabled', $user->notifications_enabled) ? 'checked' : '' }} />
+                            <x-input-error class="mt-2" :messages="$errors->get('notifications_enabled')" />
+                        </div>
+
+                        <div>
+                            <x-input-label for="language" :value="__('Language')" />
+                            <select id="language" name="language" class="mt-1 block w-full">
+                                <option value="en" {{ old('language', $user->language) == 'en' ? 'selected' : '' }}>English</option>
+                                <option value="fr" {{ old('language', $user->language) == 'fr' ? 'selected' : '' }}>Français</option>
+                                <option value="es" {{ old('language', $user->language) == 'es' ? 'selected' : '' }}>Español</option>
+                            </select>
+                            <x-input-error class="mt-2" :messages="$errors->get('language')" />
+                        </div>
+
+                        <div class="flex items-center gap-4">
+                            <x-primary-button>{{ __('Save') }}</x-primary-button>
+
+                            @if (session('status') === 'settings-updated')
+                                <p x-data="{ show: true }" x-show="show" x-transition x-init="setTimeout(() => show = false, 2000)" class="text-sm text-gray-600 dark:text-gray-400">{{ __('Saved.') }}</p>
+                            @endif
+                        </div>
+                    </form>
                 </div>
             </div>
         </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\ProfileController;
+use App\Http\Controllers\AccountSettingsController;
 use App\Livewire\Admin\Company\CompanyCreate;
 use App\Livewire\Admin\Company\CompanyIndex;
 use App\Livewire\Admin\Company\CompanyList;
@@ -63,7 +64,8 @@ Route::middleware('auth')->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
-    Route::view('/account/settings', 'account.settings')->name('account.settings');
+    Route::get('/account/settings', [AccountSettingsController::class, 'edit'])->name('account.settings');
+    Route::patch('/account/settings', [AccountSettingsController::class, 'update'])->name('account.settings.update');
 
     Route::prefix('company')->name('company.')->group(function () {
         Route::get('/Dashaboard', CompanyIndex::class)->name('index')->middleware(['permission:view company']);


### PR DESCRIPTION
## Summary
- add AccountSettingsController with edit and update actions
- enable storing notification and language preferences via migration
- switch account settings route to use controller
- enhance account settings Blade view with form

## Testing
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68486ae9677c832099cdcd95eee6c112