### PR TITLE
Add AgencyFee fillable and tests

### DIFF
--- a/app/Models/AgencyFee.php
+++ b/app/Models/AgencyFee.php
@@ -6,5 +6,9 @@ use Illuminate\Database\Eloquent\Model;
 
 class AgencyFee extends Model
 {
-    //
+    protected $fillable = [
+        'code',
+        'label',
+        'description',
+    ];
 }

--- a/tests/Feature/Livewire/Admin/AgencyFee/ManageAgencyFeeTest.php
+++ b/tests/Feature/Livewire/Admin/AgencyFee/ManageAgencyFeeTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Tests\Feature\Livewire\Admin\AgencyFee;
+
+use App\Livewire\Admin\ManageAgencyFees\ManageAgencyFee;
+use App\Models\AgencyFee;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class ManageAgencyFeeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_can_create_agency_fee(): void
+    {
+        $user = User::factory()->create();
+
+        Livewire::actingAs($user)
+            ->test(ManageAgencyFee::class)
+            ->set('code', 'AF001')
+            ->set('label', 'Agency Fee Test')
+            ->set('description', 'Some description')
+            ->call('save')
+            ->assertHasNoErrors();
+
+        $this->assertDatabaseHas('agency_fees', [
+            'code' => 'AF001',
+            'label' => 'Agency Fee Test',
+            'description' => 'Some description',
+        ]);
+    }
+
+    public function test_can_update_agency_fee(): void
+    {
+        $user = User::factory()->create();
+        $fee = AgencyFee::create([
+            'code' => 'AF002',
+            'label' => 'Old Label',
+            'description' => 'Old description',
+        ]);
+
+        Livewire::actingAs($user)
+            ->test(ManageAgencyFee::class)
+            ->call('edit', $fee->id)
+            ->set('code', 'AF002-UPDATED')
+            ->set('label', 'Updated Label')
+            ->set('description', 'Updated description')
+            ->call('update')
+            ->assertHasNoErrors();
+
+        $this->assertDatabaseHas('agency_fees', [
+            'id' => $fee->id,
+            'code' => 'AF002-UPDATED',
+            'label' => 'Updated Label',
+            'description' => 'Updated description',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add `fillable` attributes to `AgencyFee`
- test ManageAgencyFee component create and update

## Testing
- `composer install` *(fails: command not found)*
- `phpunit --version` *(fails: command not found)*
- `./vendor/bin/pest` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68495765c15c832098763b99a6a136b9