### PR TITLE
Fix Livewire layout for agency fee management

### DIFF
--- a/app/Livewire/Admin/ManageAgencyFees/ManageAgencyFee.php
+++ b/app/Livewire/Admin/ManageAgencyFees/ManageAgencyFee.php
@@ -39,7 +39,7 @@ class ManageAgencyFee extends Component
 
         return view('livewire.admin.manage-agency-fees.manage-agency-fee', [
             'fees' => $fees,
-        ]);
+        ])->layout('layouts.app');
     }
 
     public function showForm()


### PR DESCRIPTION
## Summary
- ensure `/agency-fees/index` Livewire component uses the standard layout

## Testing
- `php artisan test` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684959a47458832093d89ef3009b275b