### PR TITLE
Fix agency-fees CRUD mass assignment

### DIFF
--- a/app/Livewire/Admin/ManageAgencyFees/ManageAgencyFee.php
+++ b/app/Livewire/Admin/ManageAgencyFees/ManageAgencyFee.php
@@ -98,5 +98,6 @@ class ManageAgencyFee extends Component
     public function resetForm()
     {
         $this->reset(['agency_fee_id', 'code', 'label', 'description', 'isEditMode']);
+        $this->resetValidation();
     }
 }

--- a/app/Models/AgencyFee.php
+++ b/app/Models/AgencyFee.php
@@ -6,5 +6,14 @@ use Illuminate\Database\Eloquent\Model;
 
 class AgencyFee extends Model
 {
-    //
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'code',
+        'label',
+        'description',
+    ];
 }


### PR DESCRIPTION
## Summary
- allow mass assignment on `AgencyFee` model
- clear validation errors when resetting the agency-fee form

## Testing
- `php -l app/Models/AgencyFee.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68495d24855c8320a4f18f0eba45bc93