### PR TITLE
Add global date picker

### DIFF
--- a/resources/views/components/layouts/app.blade.php
+++ b/resources/views/components/layouts/app.blade.php
@@ -15,6 +15,7 @@
     <!-- Styles -->
     @livewireStyles
     <link href="{{ asset('css/style.css') }}" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>
 
 
@@ -59,5 +60,14 @@ $watch('darkMode', value => localStorage.setItem('darkMode', JSON.stringify(valu
         <!-- ===== Page Wrapper End ===== -->
     </div>
     @livewireScripts
+    <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            flatpickr("input[type=date]");
+        });
+        document.addEventListener('livewire:navigated', () => {
+            flatpickr("input[type=date]");
+        });
+    </script>
 </body>
 </html>

--- a/resources/views/components/layouts/guest.blade.php
+++ b/resources/views/components/layouts/guest.blade.php
@@ -14,6 +14,7 @@
 
     <!-- Scripts -->
     <link href="{{ asset('css/style.css') }}" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css" rel="stylesheet">
 </head>
 
 <body x-data="{ page: 'authentification', 'loaded': true, 'darkMode': false, 'stickyMenu': false, 'sidebarToggle': false, 'scrollTop': false }" x-init="darkMode = JSON.parse(localStorage.getItem('darkMode'));
@@ -21,6 +22,15 @@ $watch('darkMode', value => localStorage.setItem('darkMode', JSON.stringify(valu
 
     {{ $slot }}
     <script src="{{ asset('js/app.js') }}" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            flatpickr("input[type=date]");
+        });
+        document.addEventListener('livewire:navigated', () => {
+            flatpickr("input[type=date]");
+        });
+    </script>
 </body>
 
 </html>

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -15,6 +15,7 @@
     <!-- Styles -->
     @livewireStyles
     <link href="{{ asset('css/style.css') }}" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>
 
     <!-- Scripts -->
@@ -59,5 +60,14 @@ $watch('darkMode', value => localStorage.setItem('darkMode', JSON.stringify(valu
         <!-- ===== Page Wrapper End ===== -->
     </div>
     @livewireScripts
+    <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            flatpickr("input[type=date]");
+        });
+        document.addEventListener('livewire:navigated', () => {
+            flatpickr("input[type=date]");
+        });
+    </script>
 </body>
 </html>

--- a/resources/views/layouts/guest.blade.php
+++ b/resources/views/layouts/guest.blade.php
@@ -14,6 +14,7 @@
 
     <!-- Scripts -->
     <link href="{{ asset('css/style.css') }}" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css" rel="stylesheet">
 </head>
 
 <body x-data="{ page: 'authentification', 'loaded': true, 'darkMode': false, 'stickyMenu': false, 'sidebarToggle': false, 'scrollTop': false }" x-init="darkMode = JSON.parse(localStorage.getItem('darkMode'));
@@ -21,6 +22,15 @@ $watch('darkMode', value => localStorage.setItem('darkMode', JSON.stringify(valu
 
     {{ $slot }}
     <script src="{{ asset('js/app.js') }}" defer></script>
+    <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            flatpickr("input[type=date]");
+        });
+        document.addEventListener('livewire:navigated', () => {
+            flatpickr("input[type=date]");
+        });
+    </script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- include Flatpickr CSS/JS in the layouts
- automatically enable Flatpickr on all `<input type="date">`

## Testing
- `vendor/bin/pest` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68497e8efdf8832085ad53bade9b0913