### PR TITLE
Filter out deleted companies

### DIFF
--- a/app/Livewire/Admin/Dashboard/Dashboard.php
+++ b/app/Livewire/Admin/Dashboard/Dashboard.php
@@ -28,7 +28,7 @@ class Dashboard extends Component
 
         // Statistiques globales
         $totalGlobalInvoices = GlobalInvoice::count();
-        $totalCompanies = Company::count();
+        $totalCompanies = Company::notDeleted()->count();
 
         // Fichiers
         $totalUploadedFiles = FolderFile::count();
@@ -39,7 +39,7 @@ class Dashboard extends Component
         $latestFolders = Folder::with('company')->latest()->take(5)->get();
         $latestInvoices = Invoice::with('company')->latest()->take(5)->get();
         $latestGlobalInvoices = GlobalInvoice::with('company')->latest()->take(5)->get();
-        $latestCompanies = Company::latest()->take(5)->get();
+        $latestCompanies = Company::notDeleted()->latest()->take(5)->get();
 
         return view('livewire.admin.dashboard.dashboard', [
             'totalFolders' => $totalFolders,

--- a/app/Livewire/Admin/Folder/FolderCreate.php
+++ b/app/Livewire/Admin/Folder/FolderCreate.php
@@ -63,7 +63,9 @@ class FolderCreate extends Component
     {
        // $this->folder_date = now()->toDateString();
 
-        $this->companies = Company::orderBy('name')->get(['id', 'name', 'acronym']);
+        $this->companies = Company::notDeleted()
+            ->orderBy('name')
+            ->get(['id', 'name', 'acronym']);
         $this->locations = Location::orderBy('name')->get(['id', 'name']);
         $this->customsOffices = CustomsOffice::orderBy('name')->get(['id', 'name']);
         $this->declarationTypes = DeclarationType::orderBy('name')->get(['id', 'name']);
@@ -78,7 +80,7 @@ class FolderCreate extends Component
 
     public function updatedCompanyId($value)
     {
-        if ($company = Company::find($value)) {
+        if ($company = Company::notDeleted()->find($value)) {
             $this->generateFolderNumber($company->acronym ?? 'GEN');
         }
     }

--- a/app/Livewire/Admin/Invoices/GenerateInvoice.php
+++ b/app/Livewire/Admin/Invoices/GenerateInvoice.php
@@ -336,7 +336,7 @@ class GenerateInvoice extends Component
     public function render()
     {
         return view('livewire.admin.invoices.generate-invoice', [
-            'companies' => Company::all(),
+            'companies' => Company::notDeleted()->get(),
         ]);
     }
 

--- a/app/Services/Invoice/InvoiceService.php
+++ b/app/Services/Invoice/InvoiceService.php
@@ -16,7 +16,7 @@ class InvoiceService
      */
     public static function generateInvoiceNumber(int $companyId, bool $global = false): string
     {
-        $company = Company::findOrFail($companyId);
+        $company = Company::notDeleted()->findOrFail($companyId);
         $acronym = strtoupper($company->acronym);
         $prefix = 'MDB' . $acronym . ($global ? 'GLO-' : '');
 

--- a/resources/views/livewire/admin/invoices/invoice-index.blade.php
+++ b/resources/views/livewire/admin/invoices/invoice-index.blade.php
@@ -30,7 +30,7 @@
             @if ($companyIdForGlobalInvoice)
                 <span class="ml-2 text-sm text-gray-500">
                     Pour la compagnie ID: {{ $companyIdForGlobalInvoice }}
-                    ({{ \App\Models\Company::find($companyIdForGlobalInvoice)?->name ?? 'N/A' }})
+                    ({{ \App\Models\Company::notDeleted()->find($companyIdForGlobalInvoice)?->name ?? 'N/A' }})
                 </span>
             @endif
         </div>

--- a/tests/Feature/Admin/DashboardTest.php
+++ b/tests/Feature/Admin/DashboardTest.php
@@ -71,7 +71,7 @@ class DashboardTest extends TestCase
         // Ces assertions peuvent être fragiles si le formatage exact du nombre change (ex: espaces pour milliers)
         // Il est souvent préférable de vérifier la présence du label et de la donnée séparément si le formatage est complexe.
         $response->assertSeeText('Total Clients');
-        $response->assertSeeTextInOrder(['Total Clients', (string)Company::count()]);
+        $response->assertSeeTextInOrder(['Total Clients', (string)Company::notDeleted()->count()]);
 
         $response->assertSeeText('Total Dossiers');
         $response->assertSeeTextInOrder(['Total Dossiers', (string)Folder::count()]);


### PR DESCRIPTION
## Summary
- exclude companies marked `is_deleted` in folder creation page
- only show active companies when generating invoices
- hide deleted companies from dashboard counts and lists
- ensure invoice number generation uses active companies
- update invoice index view to ignore deleted companies
- adjust dashboard test accordingly

## Testing
- `vendor/bin/phpunit` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68498551e3e08320ac0eaedcf753d731