### PR TITLE
Add audit logs page

### DIFF
--- a/app/Livewire/Admin/Audit/AuditLogIndex.php
+++ b/app/Livewire/Admin/Audit/AuditLogIndex.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Livewire\Admin\Audit;
+
+use Livewire\Component;
+use Livewire\WithPagination;
+use App\Models\AuditLog;
+
+class AuditLogIndex extends Component
+{
+    use WithPagination;
+
+    public $search = '';
+    public $perPage = 10;
+
+    protected $queryString = ['search'];
+
+    public function updatingSearch()
+    {
+        $this->resetPage();
+    }
+
+    public function render()
+    {
+        $logs = AuditLog::with('user')
+            ->when($this->search, function ($query) {
+                $query->where('auditable_type', 'like', '%'.$this->search.'%')
+                    ->orWhere('operation', 'like', '%'.$this->search.'%')
+                    ->orWhere('message', 'like', '%'.$this->search.'%');
+            })
+            ->latest()
+            ->paginate($this->perPage);
+
+        return view('livewire.admin.audit.audit-log-index', [
+            'logs' => $logs,
+        ]);
+    }
+}

--- a/app/Models/AuditLog.php
+++ b/app/Models/AuditLog.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use App\Models\User;
 
 class AuditLog extends Model
 {
@@ -14,4 +15,9 @@ class AuditLog extends Model
         'previous_data' => 'array',
         'new_data' => 'array',
     ];
+
+    public function user()
+    {
+        return \$this->belongsTo(User::class);
+    }
 }

--- a/resources/views/components/partials/sidebar.blade.php
+++ b/resources/views/components/partials/sidebar.blade.php
@@ -516,6 +516,13 @@
                                             Villes
                                         </a>
                                     </li>
+                                    <li>
+                                        <a href="{{ route('audit-logs.index') }}" class="menu-dropdown-item group"
+                                            :class="page === 'AuditLogs' ? 'menu-dropdown-item-active' :
+                                                'menu-dropdown-item-inactive'">
+                                            Historiques
+                                        </a>
+                                    </li>
                                 </ul>
                             </div>
                             <!-- Dropdown Menu End -->

--- a/resources/views/livewire/admin/audit/audit-log-index.blade.php
+++ b/resources/views/livewire/admin/audit/audit-log-index.blade.php
@@ -1,0 +1,38 @@
+<div class="p-6 bg-white rounded shadow">
+    <h2 class="text-xl font-bold mb-4">📝 Historique des actions</h2>
+
+    <div class="flex mb-4 gap-2">
+        <input type="text" wire:model.lazy="search" placeholder="Rechercher..." class="border rounded px-2 py-1 w-full">
+    </div>
+
+    <table class="w-full text-sm border">
+        <thead class="bg-gray-100">
+            <tr>
+                <th class="border px-2 py-1">Date</th>
+                <th class="border px-2 py-1">Utilisateur</th>
+                <th class="border px-2 py-1">Opération</th>
+                <th class="border px-2 py-1">Modèle</th>
+                <th class="border px-2 py-1">Message</th>
+            </tr>
+        </thead>
+        <tbody>
+            @forelse ($logs as $log)
+                <tr>
+                    <td class="border px-2 py-1">{{ $log->created_at->format('d/m/Y H:i') }}</td>
+                    <td class="border px-2 py-1">{{ optional($log->user)->name ?? 'System' }}</td>
+                    <td class="border px-2 py-1">{{ $log->operation }}</td>
+                    <td class="border px-2 py-1">{{ class_basename($log->auditable_type) }}</td>
+                    <td class="border px-2 py-1">{{ $log->message }}</td>
+                </tr>
+            @empty
+                <tr>
+                    <td colspan="5" class="border px-2 py-1 text-center">Aucun log</td>
+                </tr>
+            @endforelse
+        </tbody>
+    </table>
+
+    <div class="mt-4">
+        {{ $logs->links() }}
+    </div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -176,6 +176,11 @@ Route::get('/dashboard', Dashboard::class)->name('dashboard');
         Route::get('/index', ManageAgencyFee::class)->name('index');
     });
 
+    // Audit Logs
+    Route::prefix('audit-logs')->name('audit-logs.')->group(function () {
+        Route::get('/', \App\Livewire\Admin\Audit\AuditLogIndex::class)->name('index');
+    });
+
     // Admin Routes for User, Role, Permission Management
     Route::prefix('admin')->name('admin.')->group(function () {
         // User Management


### PR DESCRIPTION
## Summary
- add an AuditLogIndex Livewire component
- show audit logs from sidebar
- add relationship to AuditLog model
- register audit routes

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68498e466fd08320ac8224c44e9fd267