### PR TITLE
Enable admin avatar management

### DIFF
--- a/app/Livewire/Admin/User/UserCreate.php
+++ b/app/Livewire/Admin/User/UserCreate.php
@@ -7,14 +7,18 @@ use App\Models\User;
 use App\Models\Role;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Gate;
+use Livewire\WithFileUploads;
 
 class UserCreate extends Component
 {
+    use WithFileUploads;
     public $name;
     public $email;
     public $password;
     public $password_confirmation;
     public $selectedRoles = [];
+
+    public $avatar;
 
     public $roles;
 
@@ -32,6 +36,7 @@ class UserCreate extends Component
             'name' => 'required|string|max:255',
             'email' => 'required|string|email|max:255|unique:users',
             'password' => 'required|string|min:8|confirmed',
+            'avatar' => 'nullable|image|max:2048',
             'selectedRoles' => 'nullable|array',
             'selectedRoles.*' => 'exists:roles,id',
         ];
@@ -41,10 +46,13 @@ class UserCreate extends Component
     {
         $this->validate();
 
+        $avatarPath = $this->avatar ? $this->avatar->store('avatars', 'public') : null;
+
         $user = User::create([
             'name' => $this->name,
             'email' => $this->email,
             'password' => Hash::make($this->password),
+            'avatar' => $avatarPath,
         ]);
 
         $user->roles()->sync($this->selectedRoles);

--- a/app/Livewire/Admin/User/UserEdit.php
+++ b/app/Livewire/Admin/User/UserEdit.php
@@ -8,15 +8,20 @@ use App\Models\Role;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\Rule;
 use Illuminate\Support\Facades\Gate;
+use Livewire\WithFileUploads;
+use Illuminate\Support\Facades\Storage;
 
 class UserEdit extends Component
 {
+    use WithFileUploads;
     public User $user;
     public $name;
     public $email;
     public $password;
     public $password_confirmation;
     public $selectedRoles = [];
+
+    public $avatar;
 
     public $roles;
 
@@ -44,6 +49,7 @@ class UserEdit extends Component
                 Rule::unique('users')->ignore($this->user->id),
             ],
             'password' => 'nullable|string|min:8|confirmed',
+            'avatar' => 'nullable|image|max:2048',
             'selectedRoles' => 'nullable|array',
             'selectedRoles.*' => 'exists:roles,id',
         ];
@@ -58,6 +64,13 @@ class UserEdit extends Component
 
         if ($this->password) {
             $this->user->password = Hash::make($this->password);
+        }
+
+        if ($this->avatar) {
+            if ($this->user->avatar) {
+                Storage::disk('public')->delete($this->user->avatar);
+            }
+            $this->user->avatar = $this->avatar->store('avatars', 'public');
         }
 
         $this->user->save();

--- a/resources/views/livewire/admin/user/user-create.blade.php
+++ b/resources/views/livewire/admin/user/user-create.blade.php
@@ -26,6 +26,15 @@
                     </div>
 
                     <div class="mb-4">
+                        <label class="block text-gray-700 text-sm font-bold mb-2" for="avatar">
+                            Avatar
+                        </label>
+                        <input wire:model="avatar" type="file" id="avatar"
+                               class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline @error('avatar') border-red-500 @enderror">
+                        @error('avatar') <p class="text-red-500 text-xs italic">{{ $message }}</p> @enderror
+                    </div>
+
+                    <div class="mb-4">
                         <label class="block text-gray-700 text-sm font-bold mb-2" for="password">
                             Password
                         </label>

--- a/resources/views/livewire/admin/user/user-edit.blade.php
+++ b/resources/views/livewire/admin/user/user-edit.blade.php
@@ -26,6 +26,15 @@
                     </div>
 
                     <div class="mb-4">
+                        <label class="block text-gray-700 text-sm font-bold mb-2" for="avatar">
+                            Avatar
+                        </label>
+                        <input wire:model="avatar" type="file" id="avatar"
+                               class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline @error('avatar') border-red-500 @enderror">
+                        @error('avatar') <p class="text-red-500 text-xs italic">{{ $message }}</p> @enderror
+                    </div>
+
+                    <div class="mb-4">
                         <label class="block text-gray-700 text-sm font-bold mb-2" for="password">
                             New Password (leave blank to keep current password)
                         </label>


### PR DESCRIPTION
## Summary
- allow administrators to upload avatars when creating or editing users
- add avatar upload field to user create/edit forms

## Testing
- `php artisan test` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6849944081dc8320bdcd436622be2e4d