### PR TITLE
Show avatars in user list

### DIFF
--- a/resources/views/livewire/admin/user/user-index.blade.php
+++ b/resources/views/livewire/admin/user/user-index.blade.php
@@ -40,6 +40,10 @@
                             <tr>
                                 <th
                                     class="px-5 py-3 border-b-2 border-gray-200 bg-gray-100 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">
+                                    Avatar
+                                </th>
+                                <th
+                                    class="px-5 py-3 border-b-2 border-gray-200 bg-gray-100 text-left text-xs font-semibold text-gray-600 uppercase tracking-wider">
                                     Name
                                 </th>
                                 <th
@@ -63,6 +67,11 @@
                         <tbody>
                             @forelse ($users as $user)
                                 <tr>
+                                    <td class="px-5 py-5 border-b border-gray-200 bg-white text-sm">
+                                        <div class="w-10 h-10 overflow-hidden rounded-full">
+                                            <img src="{{ $user->avatar ? asset('storage/' . $user->avatar) : asset('src/images/user/owner.jpg') }}" alt="{{ $user->name }}" />
+                                        </div>
+                                    </td>
                                     <td class="px-5 py-5 border-b border-gray-200 bg-white text-sm">
                                         <p class="text-gray-900 whitespace-no-wrap">{{ $user->name }}</p>
                                     </td>
@@ -90,7 +99,7 @@
                                 </tr>
                             @empty
                                 <tr>
-                                    <td colspan="5" class="px-5 py-5 border-b border-gray-200 bg-white text-sm text-center">
+                                    <td colspan="6" class="px-5 py-5 border-b border-gray-200 bg-white text-sm text-center">
                                         No users found.
                                     </td>
                                 </tr>


### PR DESCRIPTION
## Summary
- display avatar column on user list

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_684995bd762483208ea44e4fdc369e89