### PR TITLE
Fix sidebar logo text and add KelseaSoft icon

### DIFF
--- a/public/images/logo/kelseasoft.svg
+++ b/public/images/logo/kelseasoft.svg
@@ -1,0 +1,4 @@
+<svg width="64" height="64" viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
+  <rect width="64" height="64" rx="8" fill="#465FFF"/>
+  <text x="32" y="42" font-size="32" font-family="Arial, Helvetica, sans-serif" font-weight="bold" fill="white" text-anchor="middle">KS</text>
+</svg>

--- a/resources/views/components/partials/sidebar.blade.php
+++ b/resources/views/components/partials/sidebar.blade.php
@@ -6,12 +6,11 @@
         <div :class="sidebarToggle ? 'justify-center' : 'justify-between'"
             class="flex items-center gap-2 pt-8 sidebar-header pb-7">
             <a href="{{ route('dashboard') }}">
-                <span class="logo" :class="sidebarToggle ? 'hidden' : ''">
-                    <img class="dark:hidden" src="{{ asset('src/images/logo/logo.png') }}" alt="Logo" />
-                    <img class="hidden dark:block" src="{{ asset('src/images/logo/logo.png') }}" alt="Logo" />
+                <span class="logo text-xl font-semibold" :class="sidebarToggle ? 'hidden' : ''">
+                    KelseaSoft
                 </span>
                 <img class="logo-icon" :class="sidebarToggle ? 'lg:block' : 'hidden'"
-                    src="{{ asset('src/images/logo/logo.png') }}" alt="Logo" />
+                    src="{{ asset('images/logo/kelseasoft.svg') }}" alt="Logo" />
             </a>
         </div>
         <!-- SIDEBAR HEADER -->


### PR DESCRIPTION
## Summary
- simplify sidebar header by displaying `KelseaSoft` text
- add a custom `kelseasoft.svg` icon and use it for the compact sidebar view

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68499757f4008320b00cc61ea4c7dfed