### PR TITLE
Improve folder listing order

### DIFF
--- a/app/Livewire/Admin/Folder/FolderList.php
+++ b/app/Livewire/Admin/Folder/FolderList.php
@@ -65,6 +65,7 @@ class FolderList extends Component
         'bivac_code' => 'Bivac',
         'license_number' => 'License', // Assuming 'license->license_number'
         'description' => 'Desc.',
+        'created_at' => 'Created',
     ];
 
     public $visibleColumns = [
@@ -84,7 +85,8 @@ class FolderList extends Component
         if (empty($this->visibleColumns)) {
             $this->visibleColumns = [
                 'folder_number', 'truck_number', 'company_name',
-                'arrival_border_date', 'goods_type', 'transporter_name', 'declaration_number'
+                'arrival_border_date', 'goods_type', 'transporter_name', 'declaration_number',
+                'created_at'
             ];
         }
     }
@@ -124,7 +126,7 @@ class FolderList extends Component
             ->when($this->filterTransporter, fn($q) => $q->where('transporter_id', $this->filterTransporter))
             ->when($this->filterDateFrom, fn($q) => $q->whereDate('arrival_border_date', '>=', $this->filterDateFrom))
             ->when($this->filterDateTo, fn($q) => $q->whereDate('arrival_border_date', '<=', $this->filterDateTo))
-            ->latest()
+            ->orderBy('created_at')
             ->paginate($this->perPage);
 
         return view('livewire.admin.folder.folder-list', [

--- a/resources/views/livewire/admin/folder/folder-list.blade.php
+++ b/resources/views/livewire/admin/folder/folder-list.blade.php
@@ -76,6 +76,9 @@
                                             @case('license_number')
                                                 {{ $folder->license?->license_number }}
                                                 @break
+                                            @case('created_at')
+                                                {{ $folder->created_at->format('Y-m-d') }}
+                                                @break
                                             @case('folder_date')
                                             @case('arrival_border_date')
                                             @case('tr8_date')


### PR DESCRIPTION
## Summary
- show creation date column in FolderList
- default sorting by creation date
- render creation date in the list view

## Testing
- `./vendor/bin/pest` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684adc963578832093830d9ded5cdae7