### PR TITLE
Add dropdown action menu to folder list

### DIFF
--- a/resources/views/livewire/admin/folder/folder-list.blade.php
+++ b/resources/views/livewire/admin/folder/folder-list.blade.php
@@ -105,7 +105,21 @@
                                 @endif
                             @endforeach
                             <td class="px-4 py-3">
-                                <button wire:click="archiveFolder({{ $folder->id }})" class="text-red-600 hover:underline">Archiver</button>
+                                <x-dropdown align="right" width="48">
+                                    <x-slot name="trigger">
+                                        <button class="text-gray-500 hover:text-gray-700">•••</button>
+                                    </x-slot>
+
+                                    <x-slot name="content">
+                                        <x-dropdown-link :href="route('folder.show', $folder->id)">Afficher</x-dropdown-link>
+                                        <x-dropdown-link :href="route('folder.edit', $folder->id)">Modifier</x-dropdown-link>
+                                        <button wire:click="archiveFolder({{ $folder->id }})"
+                                            onclick="return confirm('Archiver ce dossier ?');"
+                                            class="w-full text-left block px-4 py-2 text-sm text-red-600 hover:bg-gray-100">
+                                            Archiver
+                                        </button>
+                                    </x-slot>
+                                </x-dropdown>
                             </td>
                         </tr>
                     @empty


### PR DESCRIPTION
## Summary
- convert folder action buttons into a dropdown menu for a cleaner UI

## Testing
- `composer test -- --filter=whatever` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684ae1f3dce483208786afff1c517087