### PR TITLE
Add archived items counts

### DIFF
--- a/app/Livewire/Admin/Archive/ArchiveIndex.php
+++ b/app/Livewire/Admin/Archive/ArchiveIndex.php
@@ -39,6 +39,9 @@ class ArchiveIndex extends Component
             'trashedFolders' => Folder::onlyTrashed()->paginate(10),
             'trashedInvoices' => Invoice::onlyTrashed()->with('company')->paginate(10),
             'trashedGlobalInvoices' => GlobalInvoice::onlyTrashed()->with('company')->paginate(10),
+            'trashedFoldersCount' => Folder::onlyTrashed()->count(),
+            'trashedInvoicesCount' => Invoice::onlyTrashed()->count(),
+            'trashedGlobalInvoicesCount' => GlobalInvoice::onlyTrashed()->count(),
         ]);
     }
 }

--- a/app/Livewire/Admin/Dashboard/Dashboard.php
+++ b/app/Livewire/Admin/Dashboard/Dashboard.php
@@ -46,6 +46,10 @@ class Dashboard extends Component
         $archivedInvoices = Invoice::onlyTrashed()->latest()->take(5)->get();
         $archivedGlobalInvoices = GlobalInvoice::onlyTrashed()->latest()->take(5)->get();
 
+        $archivedFoldersCount = Folder::onlyTrashed()->count();
+        $archivedInvoicesCount = Invoice::onlyTrashed()->count();
+        $archivedGlobalInvoicesCount = GlobalInvoice::onlyTrashed()->count();
+
         return view('livewire.admin.dashboard.dashboard', [
             'totalFolders' => $totalFolders,
             'foldersThisMonth' => $foldersThisMonth,
@@ -65,6 +69,9 @@ class Dashboard extends Component
             'archivedFolders' => $archivedFolders,
             'archivedInvoices' => $archivedInvoices,
             'archivedGlobalInvoices' => $archivedGlobalInvoices,
+            'archivedFoldersCount' => $archivedFoldersCount,
+            'archivedInvoicesCount' => $archivedInvoicesCount,
+            'archivedGlobalInvoicesCount' => $archivedGlobalInvoicesCount,
         ]);
     }
 }

--- a/resources/views/livewire/admin/archive/archive-index.blade.php
+++ b/resources/views/livewire/admin/archive/archive-index.blade.php
@@ -7,7 +7,7 @@
         </div>
     @endif
 
-    <h3 class="font-semibold mt-4">Dossiers Archivés</h3>
+    <h3 class="font-semibold mt-4">Dossiers Archivés ({{ $trashedFoldersCount }})</h3>
     <table class="w-full border mt-2 text-sm">
         <thead class="bg-gray-100">
             <tr>
@@ -32,7 +32,7 @@
     </table>
     {{ $trashedFolders->links() }}
 
-    <h3 class="font-semibold mt-8">Factures Archivées</h3>
+    <h3 class="font-semibold mt-8">Factures Archivées ({{ $trashedInvoicesCount }})</h3>
     <table class="w-full border mt-2 text-sm">
         <thead class="bg-gray-100">
             <tr>
@@ -59,7 +59,7 @@
     </table>
     {{ $trashedInvoices->links() }}
 
-    <h3 class="font-semibold mt-8">Factures Globales Archivées</h3>
+    <h3 class="font-semibold mt-8">Factures Globales Archivées ({{ $trashedGlobalInvoicesCount }})</h3>
     <table class="w-full border mt-2 text-sm">
         <thead class="bg-gray-100">
             <tr>

--- a/resources/views/livewire/admin/dashboard/dashboard.blade.php
+++ b/resources/views/livewire/admin/dashboard/dashboard.blade.php
@@ -120,7 +120,7 @@
         <h3 class="text-lg font-semibold text-gray-800 dark:text-white mb-4">Fichiers Archivés</h3>
         <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
             <div>
-                <h4 class="font-medium mb-2">Dossiers</h4>
+                <h4 class="font-medium mb-2">Dossiers ({{ $archivedFoldersCount }})</h4>
                 @forelse($archivedFolders as $folder)
                     <p class="text-sm mb-1">N° {{ $folder->folder_number }}</p>
                 @empty
@@ -128,7 +128,7 @@
                 @endforelse
             </div>
             <div>
-                <h4 class="font-medium mb-2">Factures</h4>
+                <h4 class="font-medium mb-2">Factures ({{ $archivedInvoicesCount }})</h4>
                 @forelse($archivedInvoices as $invoice)
                     <p class="text-sm mb-1">{{ $invoice->invoice_number }}</p>
                 @empty
@@ -136,7 +136,7 @@
                 @endforelse
             </div>
             <div>
-                <h4 class="font-medium mb-2">Factures Globales</h4>
+                <h4 class="font-medium mb-2">Factures Globales ({{ $archivedGlobalInvoicesCount }})</h4>
                 @forelse($archivedGlobalInvoices as $global)
                     <p class="text-sm mb-1">{{ $global->global_invoice_number }}</p>
                 @empty


### PR DESCRIPTION
## Summary
- show totals for archived folders and invoices in dashboard
- display archive counts in archives list page

## Testing
- `./vendor/bin/pest` *(fails: No such file or directory)*
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ae5eebbd083208da359f20c2d439d