### PR TITLE
Add filters to invoice index

### DIFF
--- a/app/Livewire/Admin/Invoices/InvoiceIndex.php
+++ b/app/Livewire/Admin/Invoices/InvoiceIndex.php
@@ -21,8 +21,26 @@ class InvoiceIndex extends Component
     public array $selectedInvoices = [];
     public ?int $companyIdForGlobalInvoice = null;
 
+    public ?string $filterDate = null;
+    public string $filterCode = '';
+
     public ?int $deleteInvoiceId = null;
     public string $deleteConfirmText = '';
+
+    public function updatingSearch(): void
+    {
+        $this->resetPage();
+    }
+
+    public function updatingFilterDate(): void
+    {
+        $this->resetPage();
+    }
+
+    public function updatingFilterCode(): void
+    {
+        $this->resetPage();
+    }
 
     public function getInvoiceToDeleteProperty()
     {
@@ -155,6 +173,8 @@ class InvoiceIndex extends Component
                 $query->where('invoice_number', 'like', "%{$this->search}%")
                     ->orWhereHas('company', fn($q) => $q->where('name', 'like', "%{$this->search}%"));
             })
+            ->when($this->filterDate, fn($q) => $q->whereDate('invoice_date', $this->filterDate))
+            ->when($this->filterCode, fn($q) => $q->where('operation_code', 'like', "%{$this->filterCode}%"))
             ->when($this->showTrashed, fn($q) => $q->onlyTrashed())
             ->latest()
             ->paginate(10);

--- a/resources/views/livewire/admin/invoices/invoice-index.blade.php
+++ b/resources/views/livewire/admin/invoices/invoice-index.blade.php
@@ -2,8 +2,13 @@
 <div class="w-full max-w-6xl mx-auto p-6 bg-white rounded-xl shadow space-y-6">
     <div class="flex justify-between items-center">
         <h2 class="text-xl font-bold">📋 Factures Générées</h2>
-        <input type="text" wire:model.live.debounce.500ms="search" placeholder="🔍 Rechercher..."
-            class="border rounded px-3 py-1 text-sm w-1/3" />
+        <div class="flex space-x-2">
+            <input type="text" wire:model.live.debounce.500ms="search" placeholder="🔍 Rechercher..."
+                class="border rounded px-3 py-1 text-sm" />
+            <input type="text" wire:model.live.debounce.500ms="filterCode" placeholder="Code"
+                class="border rounded px-3 py-1 text-sm" />
+            <input type="date" wire:model.live="filterDate" class="border rounded px-3 py-1 text-sm" />
+        </div>
     </div>
 
     {{-- Notifications Flash --}}


### PR DESCRIPTION
## Summary
- add date and operation code filters to `InvoiceIndex` component
- render input fields for new filters in invoice index view

## Testing
- `composer install --no-interaction --no-progress` *(fails: composer not found)*
- `php -v` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ae8c3773c8320b88dbc612c48e185