### PR TITLE
Allow multiple invoices per folder

### DIFF
--- a/app/Livewire/Admin/Invoices/GenerateInvoice.php
+++ b/app/Livewire/Admin/Invoices/GenerateInvoice.php
@@ -179,7 +179,6 @@ class GenerateInvoice extends Component
                     'nullable',
                     'integer',
                     'exists:folders,id',
-                    \Illuminate\Validation\Rule::unique('invoices', 'folder_id')->whereNull('deleted_at')->ignore($this->invoice_id ?? null),
                 ],
             ]);
 

--- a/database/migrations/2025_10_01_000001_remove_unique_index_on_invoices_folder_id.php
+++ b/database/migrations/2025_10_01_000001_remove_unique_index_on_invoices_folder_id.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('invoices', function (Blueprint $table) {
+            $table->dropUnique('invoices_folder_id_unique');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('invoices', function (Blueprint $table) {
+            $table->unique('folder_id');
+        });
+    }
+};

--- a/tests/Feature/Admin/InvoiceFolderLinkTest.php
+++ b/tests/Feature/Admin/InvoiceFolderLinkTest.php
@@ -152,7 +152,7 @@ class InvoiceFolderLinkTest extends TestCase
     }
 
     /** @test */
-    public function test_cannot_create_invoice_if_folder_is_already_linked_on_save(): void
+    public function test_can_create_multiple_invoices_for_same_folder(): void
     {
         // Arrange: Crée un dossier déjà lié à une facture
         $currencyUSD = Currency::where('code', 'USD')->first();
@@ -182,9 +182,9 @@ class InvoiceFolderLinkTest extends TestCase
             ])
             ->set('folder_id', $linkedFolder->id)
             ->call('save')
-            ->assertHasErrors(['folder_id' => 'unique']);
+            ->assertHasNoErrors();
 
-        $this->assertEquals(1, Invoice::where('folder_id', $linkedFolder->id)->count());
+        $this->assertEquals(2, Invoice::where('folder_id', $linkedFolder->id)->count());
     }
 
     /** @test */


### PR DESCRIPTION
## Summary
- drop unique constraint on invoices.folder_id via new migration
- update invoice creation validation
- adjust tests to support multiple invoices per folder

## Testing
- `php vendor/bin/pest` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684c2f3786c88320b0771dbf1c64a903