### PR TITLE
Adjust invoice number suffix logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ KelseaSoft is a powerful and intuitive **customs agency management software** de
 ### 🧾 Invoicing System
 - Link invoices to dossiers with the ability to **input liquidation elements, fees, and expenses**.
 - Generate invoices in **PDF format** with the header of each company.
-- Invoice numbers use the format `MDB<ACRONYM>[GL]NNmmyy` where the company acronym, month, and year are included.
+- Invoice numbers use two different formats:
+  - For **regular invoices**: `MDB<ACRONYM>NNyy` (year only).
+  - For **global invoices**: `MDB<ACRONYM>GLNNmmyy` (includes month and year).
 - Sequential numbering begins at **335** for invoices and **057** for global invoices.
 - Track payment status (**Paid, Pending, Partially Paid**).
 

--- a/app/Services/Invoice/InvoiceService.php
+++ b/app/Services/Invoice/InvoiceService.php
@@ -41,7 +41,11 @@ class InvoiceService
         }
         $padLength = max(3, strlen((string) $start));
         $sequential = str_pad($next, $padLength, '0', STR_PAD_LEFT);
-        $suffix = Carbon::now()->format('my');
+        // Include month in the suffix only for global invoices
+        $suffix = $global
+            ? Carbon::now()->format('my')
+            : Carbon::now()->format('y');
+
         return $prefix . $sequential . $suffix;
     }
 }

--- a/tests/Feature/Admin/InvoiceFolderLinkTest.php
+++ b/tests/Feature/Admin/InvoiceFolderLinkTest.php
@@ -146,7 +146,8 @@ class InvoiceFolderLinkTest extends TestCase
         $this->assertEquals(1, Invoice::where('folder_id', $folder->id)->count());
         $invoice = Invoice::where('folder_id', $folder->id)->first();
         $expectedPrefix = 'MDB' . strtoupper($this->company->acronym);
-        $this->assertMatchesRegularExpression('/^' . $expectedPrefix . '\\d{2,}' . date('my') . '$/', $invoice->invoice_number);
+        // Partial invoices no longer include the month in the invoice number
+        $this->assertMatchesRegularExpression('/^' . $expectedPrefix . '\\d{2,}' . date('y') . '$/', $invoice->invoice_number);
         // Le test du message flash de succès peut être instable si le composant est réinitialisé différemment.
         // session()->get('success') pourrait être vérifié directement si Livewire::assertSessionHas ne fonctionne pas comme attendu après un call.
     }


### PR DESCRIPTION
## Summary
- show month only for global invoices when generating invoice numbers
- adjust expected invoice number pattern in tests
- document the new invoice numbering formats

## Testing
- `./vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c380927e883209ab31d2f7381fc21