### PR TITLE
Fix folder edit view warnings

### DIFF
--- a/resources/views/livewire/admin/folder/folder-edit.blade.php
+++ b/resources/views/livewire/admin/folder/folder-edit.blade.php
@@ -18,7 +18,7 @@
                     <x-forms.input label="Pre-alert Place" model="folder.pre_alert_place" />
                     <x-forms.input label="Transport Mode" model="folder.transport_mode" />
                     <x-forms.select label="Dossier Type" model="folder.dossier_type" :options="$dossierTypeOptions" option-label="label" option-value="value" />
-                    @if($folder['dossier_type'] === 'avec')
+                    @if(($folder['dossier_type'] ?? null) === 'avec')
                         <x-forms.select label="License" model="folder.license_id" :options="$licenses" option-label="license_number" option-value="id" />
                     @endif
                     <x-forms.input label="License Code" model="folder.license_code" />


### PR DESCRIPTION
## Summary
- fix PHP notice when dossier_type is undefined in folder edit form

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c73c216448320b6385a6bc1ff4480