### PR TITLE
Fix folder edit form prefill

### DIFF
--- a/app/Livewire/Admin/Folder/FolderEdit.php
+++ b/app/Livewire/Admin/Folder/FolderEdit.php
@@ -45,10 +45,10 @@ class FolderEdit extends Component
 
     public $dossierTypeOptions;
 
-    public function mount(Folder $folder)
+    public function mount($id)
     {
-        $this->folderModel = $folder;
-        $this->folder = $folder->toArray();
+        $this->folderModel = FolderService::getFolder($id);
+        $this->folder = $this->folderModel->toArray();
 
         $this->clients = CompanyService::getAllCompanies();
         $this->transporters = Transporter::all();


### PR DESCRIPTION
## Summary
- load Folder data by ID when editing

## Testing
- `./vendor/bin/pest -v` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684c74f1f0d08320a6178c26ec3c04d3