### PR TITLE
Add enterprise module for dynamic invoice info

### DIFF
--- a/app/Livewire/Admin/Enterprise/EnterpriseEdit.php
+++ b/app/Livewire/Admin/Enterprise/EnterpriseEdit.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Livewire\Admin\Enterprise;
+
+use Livewire\Component;
+use App\Services\Enterprise\EnterpriseService;
+use App\Models\Enterprise;
+
+class EnterpriseEdit extends Component
+{
+    public Enterprise $enterprise;
+
+    public $name;
+    public $tagline;
+    public $tax_id;
+    public $commercial_register;
+    public $national_identification;
+    public $agreement_number;
+    public $phone_number;
+    public $email;
+    public $physical_address;
+    public $footer_note;
+    public $logo;
+
+    public function mount(): void
+    {
+        $this->enterprise = EnterpriseService::getEnterprise();
+        $this->fill($this->enterprise->toArray());
+    }
+
+    protected function rules(): array
+    {
+        return [
+            'name' => 'required|string|max:255',
+            'tagline' => 'nullable|string|max:255',
+            'tax_id' => 'nullable|string|max:100',
+            'commercial_register' => 'nullable|string|max:100',
+            'national_identification' => 'nullable|string|max:100',
+            'agreement_number' => 'nullable|string|max:100',
+            'phone_number' => 'nullable|string|max:50',
+            'email' => 'nullable|email|max:100',
+            'physical_address' => 'nullable|string|max:255',
+            'footer_note' => 'nullable|string|max:255',
+            'logo' => 'nullable|string|max:255',
+        ];
+    }
+
+    public function save(): void
+    {
+        $data = $this->validate();
+        EnterpriseService::updateEnterprise($data);
+        session()->flash('success', 'Informations mises à jour.');
+    }
+
+    public function render()
+    {
+        return view('livewire.admin.enterprise.enterprise-edit');
+    }
+}

--- a/app/Livewire/Admin/Invoices/GlobalInvoiceShow.php
+++ b/app/Livewire/Admin/Invoices/GlobalInvoiceShow.php
@@ -6,6 +6,7 @@ use App\Models\GlobalInvoice;
 use Livewire\Component;
 use Barryvdh\DomPDF\Facade\Pdf; // Assurez-vous que Barryvdh DomPDF est installé et configuré
 use Symfony\Component\HttpFoundation\StreamedResponse;
+use App\Services\Enterprise\EnterpriseService;
 
 class GlobalInvoiceShow extends Component
 {
@@ -25,7 +26,11 @@ class GlobalInvoiceShow extends Component
     {
         $filename = 'Facture_Globale_' . $this->globalInvoice->global_invoice_number . '.pdf';
 
-        $pdf = Pdf::loadView('pdf.global_invoice', ['globalInvoice' => $this->globalInvoice]);
+        $enterprise = EnterpriseService::getEnterprise();
+        $pdf = Pdf::loadView('pdf.global_invoice', [
+            'globalInvoice' => $this->globalInvoice,
+            'enterprise' => $enterprise,
+        ]);
         // La vue 'pdf.global_invoice' doit être créée.
         // Elle recevra la variable $globalInvoice contenant l'objet GlobalInvoice avec ses relations chargées.
 
@@ -37,6 +42,8 @@ class GlobalInvoiceShow extends Component
 
     public function render()
     {
-        return view('livewire.admin.invoices.global-invoice-show'); // Supposant une layout admin existante
+        return view('livewire.admin.invoices.global-invoice-show', [
+            'enterprise' => EnterpriseService::getEnterprise(),
+        ]); // Supposant une layout admin existante
     }
 }

--- a/app/Livewire/Admin/Invoices/ShowInvoice.php
+++ b/app/Livewire/Admin/Invoices/ShowInvoice.php
@@ -7,6 +7,7 @@ use App\Models\Invoice;
 use Barryvdh\DomPDF\Facade\Pdf;
 use Illuminate\Support\Facades\Log;
 use Symfony\Component\HttpFoundation\StreamedResponse;
+use App\Services\Enterprise\EnterpriseService;
 
 class ShowInvoice extends Component
 {
@@ -29,7 +30,11 @@ class ShowInvoice extends Component
     {
         $filename = 'Facture_' . $this->invoice->invoice_number . '.pdf';
 
-        $pdf = Pdf::loadView('pdf.invoice', ['invoice' => $this->invoice]);
+        $enterprise = EnterpriseService::getEnterprise();
+        $pdf = Pdf::loadView('pdf.invoice', [
+            'invoice' => $this->invoice,
+            'enterprise' => $enterprise,
+        ]);
 
         return response()->streamDownload(
             fn () => print($pdf->output()),
@@ -43,6 +48,8 @@ class ShowInvoice extends Component
      */
     public function render()
     {
-        return view('livewire.admin.invoices.show-invoice');
+        return view('livewire.admin.invoices.show-invoice', [
+            'enterprise' => EnterpriseService::getEnterprise(),
+        ]);
     }
 }

--- a/app/Models/Enterprise.php
+++ b/app/Models/Enterprise.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Enterprise extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'tagline',
+        'tax_id',
+        'commercial_register',
+        'national_identification',
+        'agreement_number',
+        'phone_number',
+        'email',
+        'physical_address',
+        'footer_note',
+        'logo',
+    ];
+}

--- a/app/Services/Enterprise/EnterpriseService.php
+++ b/app/Services/Enterprise/EnterpriseService.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Services\Enterprise;
+
+use App\Models\Enterprise;
+use Illuminate\Support\Facades\DB;
+
+class EnterpriseService
+{
+    public static function getEnterprise(): Enterprise
+    {
+        return Enterprise::firstOrCreate(['id' => 1], ['name' => '']);
+    }
+
+    public static function updateEnterprise(array $data): Enterprise
+    {
+        return DB::transaction(function () use ($data) {
+            $enterprise = self::getEnterprise();
+            $enterprise->update($data);
+            return $enterprise;
+        });
+    }
+}

--- a/database/migrations/2025_04_10_084859_create_entreprises_table.php
+++ b/database/migrations/2025_04_10_084859_create_entreprises_table.php
@@ -13,6 +13,17 @@ return new class extends Migration
     {
         Schema::create('entreprises', function (Blueprint $table) {
             $table->id();
+            $table->string('name');
+            $table->string('tagline')->nullable();
+            $table->string('tax_id')->nullable();
+            $table->string('commercial_register')->nullable();
+            $table->string('national_identification')->nullable();
+            $table->string('agreement_number')->nullable();
+            $table->string('phone_number')->nullable();
+            $table->string('email')->nullable();
+            $table->string('physical_address')->nullable();
+            $table->text('footer_note')->nullable();
+            $table->string('logo')->nullable();
             $table->timestamps();
         });
     }

--- a/resources/views/livewire/admin/enterprise/enterprise-edit.blade.php
+++ b/resources/views/livewire/admin/enterprise/enterprise-edit.blade.php
@@ -1,0 +1,23 @@
+<div class="w-full mx-auto bg-white p-6 rounded-xl shadow space-y-6">
+    <h2 class="text-xl font-bold">🏢 Établissement</h2>
+
+    @if (session()->has('success'))
+        <div class="bg-green-100 text-green-700 px-3 py-2 rounded">{{ session('success') }}</div>
+    @endif
+
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <x-forms.input label="Nom" model="name" />
+        <x-forms.input label="Slogan" model="tagline" />
+        <x-forms.input label="N° Impôt" model="tax_id" />
+        <x-forms.input label="RCCM" model="commercial_register" />
+        <x-forms.input label="ID National" model="national_identification" />
+        <x-forms.input label="N° Agrément" model="agreement_number" />
+        <x-forms.input label="Téléphone" model="phone_number" />
+        <x-forms.input label="Email" model="email" type="email" />
+        <x-forms.input label="Adresse" model="physical_address" />
+        <x-forms.input label="Note pied de page" model="footer_note" />
+        <x-forms.input label="Logo (URL)" model="logo" />
+    </div>
+
+    <button wire:click="save" class="bg-blue-600 text-white px-4 py-2 rounded">💾 Enregistrer</button>
+</div>

--- a/resources/views/pdf/global_invoice.blade.php
+++ b/resources/views/pdf/global_invoice.blade.php
@@ -53,18 +53,20 @@
     <{{-- En-tête société --}} <table class="no-border" style="width: 100%; margin-bottom: 10px; border-collapse: collapse;">
         <tr>
             <td style="width: 22%; vertical-align: middle; text-align: left;">
-                <img src="{{ public_path('images/logo.png') }}" alt="Logo" style="max-height: 90px;">
+                <img src="{{ $enterprise->logo ? public_path($enterprise->logo) : public_path('images/logo.png') }}" alt="Logo" style="max-height: 90px;">
             </td>
             <td style="width: 78%; vertical-align: middle; text-align: center; padding-left: 10px;">
-                <h2 style="margin: 0; font-size: 16px;">LA MANNE DES BRAVES S.A.R.L</h2>
-                <p style="margin: 2px 0; font-size: 11px; font-weight: bold;">
-                    TRANSITAIRE EN DOUANE OFFICIEL – VOTRE SATISFACTION, C'EST NOTRE AFFAIRE
+                <h2 style="margin: 0; font-size: 16px;">{{ $enterprise->name }}</h2>
+                @if ($enterprise->tagline)
+                    <p style="margin: 2px 0; font-size: 11px; font-weight: bold;">{{ $enterprise->tagline }}</p>
+                @endif
+                <p style="margin: 2px 0; font-size: 10px;">
+                    N° Impôt : {{ $enterprise->tax_id }}
+                    &nbsp;&nbsp;&nbsp; RCCM : {{ $enterprise->commercial_register }}
                 </p>
                 <p style="margin: 2px 0; font-size: 10px;">
-                    N° Impôt : A1000859K &nbsp;&nbsp;&nbsp; RCCM : CDL/SHR/RCM15-B3463
-                </p>
-                <p style="margin: 2px 0; font-size: 10px;">
-                    ID. NAT : 05-H1901-N57656K &nbsp;&nbsp;&nbsp; NUMÉRO AGREMENT : 000188
+                    ID. NAT : {{ $enterprise->national_identification }}
+                    &nbsp;&nbsp;&nbsp; NUMÉRO AGREMENT : {{ $enterprise->agreement_number }}
                 </p>
             </td>
         </tr>
@@ -156,13 +158,9 @@
 
         <p class="right" style="margin-top: 10px;">CHRISTELLE NTANGA<br><strong>RESP FACTURATION</strong></p>
 
-        <p class="center" style="margin-top: 6px; font-size: 9px;">
-            960, Av. Chaussée Laurent Désiré Kabila, Immeuble Méthodiste, 2ème étage<br>
-            Quartier Makatano, Commune de Lubumbashi<br>
-            Tél : (+243)998180745, (+243)815056461, (+243)0977960987<br>
-            E-mail : mannedesbraves@yahoo.fr, infos@mannedesbraves.com<br>
-            Représentations : Kinshasa - Matadi - Kasumbalesa - Kolwezi
-        </p>
+        @if ($enterprise->footer_note)
+            <p class="center" style="margin-top: 6px; font-size: 9px;">{!! nl2br(e($enterprise->footer_note)) !!}</p>
+        @endif
 </body>
 
 </html>

--- a/resources/views/pdf/invoice.blade.php
+++ b/resources/views/pdf/invoice.blade.php
@@ -64,18 +64,20 @@
     <table class="no-border" style="width: 100%; margin-bottom: 10px; border-collapse: collapse;">
         <tr>
             <td style="width: 22%; vertical-align: middle; text-align: left;">
-                <img src="{{ public_path('images/logo.png') }}" alt="Logo" style="max-height: 90px;">
+                <img src="{{ $enterprise->logo ? public_path($enterprise->logo) : public_path('images/logo.png') }}" alt="Logo" style="max-height: 90px;">
             </td>
             <td style="width: 78%; vertical-align: middle; text-align: center; padding-left: 10px;">
-                <h2 style="margin: 0; font-size: 16px;">LA MANNE DES BRAVES S.A.R.L</h2>
-                <p style="margin: 2px 0; font-size: 11px; font-weight: bold;">
-                    TRANSITAIRE EN DOUANE OFFICIEL – VOTRE SATISFACTION, C'EST NOTRE AFFAIRE
+                <h2 style="margin: 0; font-size: 16px;">{{ $enterprise->name }}</h2>
+                @if ($enterprise->tagline)
+                    <p style="margin: 2px 0; font-size: 11px; font-weight: bold;">{{ $enterprise->tagline }}</p>
+                @endif
+                <p style="margin: 2px 0; font-size: 10px;">
+                    N° Impôt : {{ $enterprise->tax_id }}
+                    &nbsp;&nbsp;&nbsp; RCCM : {{ $enterprise->commercial_register }}
                 </p>
                 <p style="margin: 2px 0; font-size: 10px;">
-                    N° Impôt : A1000859K &nbsp;&nbsp;&nbsp; RCCM : CDL/SHR/RCM15-B3463
-                </p>
-                <p style="margin: 2px 0; font-size: 10px;">
-                    ID. NAT : 05-H1901-N57656K &nbsp;&nbsp;&nbsp; NUMÉRO AGREMENT : 000188
+                    ID. NAT : {{ $enterprise->national_identification }}
+                    &nbsp;&nbsp;&nbsp; NUMÉRO AGREMENT : {{ $enterprise->agreement_number }}
                 </p>
             </td>
         </tr>
@@ -283,12 +285,9 @@
     {{-- Signature --}}
     <p class="right" style="margin-top: 6px;">CHRISTELLE NTANGA<br><strong>RESP FACTURATION</strong></p>
     <hr style="border: none; border-top: 1px solid #333; margin: 8px 0;">
-    <p class="center" style="font-size: 8px; margin-top: 4px;">
-        960, Av. Chaussée Laurent Désiré Kabila, Immeuble Méthodiste, 2ème étage – Quartier Makatano, Commune de
-        Lubumbashi<br>
-        Tél : (+243)998180745, (+243)815056461, (+243)0977960987 – E-mail : mannedesbraves@yahoo.fr<br>
-        Représentations : Kinshasa - Matadi - Kasumbalesa - Kolwezi
-    </p>
+    @if ($enterprise->footer_note)
+        <p class="center" style="font-size: 8px; margin-top: 4px;">{!! nl2br(e($enterprise->footer_note)) !!}</p>
+    @endif
 
 </body>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -71,6 +71,8 @@ Route::get('/notifications/latest', [NotificationController::class, 'latest'])->
     Route::get('/account/settings', [AccountSettingsController::class, 'edit'])->name('account.settings');
     Route::patch('/account/settings', [AccountSettingsController::class, 'update'])->name('account.settings.update');
 
+    Route::get('/enterprise', \App\Livewire\Admin\Enterprise\EnterpriseEdit::class)->name('enterprise.edit');
+
     Route::prefix('company')->name('company.')->group(function () {
         Route::get('/Dashaboard', CompanyIndex::class)->name('index')->middleware(['permission:view company']);
         Route::get('/create', CompanyCreate::class)->name('create')->middleware(['permission:create company']);


### PR DESCRIPTION
## Summary
- add `Enterprise` model with service and Livewire editor
- update migration for `entreprises` table
- expose enterprise edit route
- hook enterprise details into invoice generation
- use enterprise data in invoice PDF templates

## Testing
- `npm -v`

------
https://chatgpt.com/codex/tasks/task_e_684c872497188320a9095a63939ac6f0