### PR TITLE
Fix Enterprise table configuration

### DIFF
--- a/app/Models/Enterprise.php
+++ b/app/Models/Enterprise.php
@@ -9,6 +9,15 @@ class Enterprise extends Model
 {
     use HasFactory;
 
+    /**
+     * The table associated with the model.
+     *
+     * This application historically used the French table name
+     * "entreprises". Explicitly defining the table avoids issues when
+     * Laravel tries to infer the English pluralised form "enterprises".
+     */
+    protected $table = 'entreprises';
+
     protected $fillable = [
         'name',
         'tagline',


### PR DESCRIPTION
## Summary
- explicitly set the enterprises table name to match the existing migration

## Testing
- `npm --version`
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850215f7a5083209fabc1745a85db36