### PR TITLE
Add goods_type fillable and assert in creation test

### DIFF
--- a/app/Models/Folder.php
+++ b/app/Models/Folder.php
@@ -23,6 +23,7 @@ class Folder extends Model
         'truck_number',
         'trailer_number',
         'invoice_number',
+        'goods_type',
         'transporter_id',
         'driver_name',
         'driver_phone',

--- a/tests/Feature/Livewire/Admin/Folder/FolderCreationTest.php
+++ b/tests/Feature/Livewire/Admin/Folder/FolderCreationTest.php
@@ -48,5 +48,6 @@ class FolderCreationTest extends TestCase
         $this->assertNull($folder->invoice_number);
         $this->assertEquals('TRK-123', $folder->truck_number);
         $this->assertEquals($company->id, $folder->company_id);
+        $this->assertEquals($type->name, $folder->goods_type);
     }
 }


### PR DESCRIPTION
## Summary
- allow `goods_type` mass assignment in `Folder`
- verify `goods_type` persistence in folder creation test

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850271945208320a685d1155ee79074