### PR TITLE
Auto add missing folder fields

### DIFF
--- a/app/Observers/DocumentTypeObserver.php
+++ b/app/Observers/DocumentTypeObserver.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\DocumentType;
+use App\Services\Folder\FolderFieldService;
+
+class DocumentTypeObserver
+{
+    /**
+     * Handle the DocumentType "saved" event.
+     */
+    public function saved(DocumentType $documentType): void
+    {
+        if ($documentType->folder_field) {
+            FolderFieldService::ensureFieldExists($documentType->folder_field);
+        }
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -7,6 +7,7 @@ use App\Models\DocumentType;
 use App\Models\Folder;
 use App\Models\FolderFile;
 use App\Observers\AuditObserver;
+use App\Observers\DocumentTypeObserver;
 use Illuminate\Pagination\Paginator;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\ServiceProvider;
@@ -30,5 +31,7 @@ class AppServiceProvider extends ServiceProvider
         Gate::before(fn () => true);
 
         Paginator::useTailwind();
+
+        DocumentType::observe(DocumentTypeObserver::class);
     }
 }

--- a/app/Services/Folder/FolderFieldService.php
+++ b/app/Services/Folder/FolderFieldService.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Services\Folder;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class FolderFieldService
+{
+    /**
+     * Ensure a column exists on the folders table.
+     */
+    public static function ensureFieldExists(string $field): void
+    {
+        if (!Schema::hasColumn('folders', $field)) {
+            Schema::table('folders', function (Blueprint $table) use ($field) {
+                $table->string($field)->nullable();
+            });
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- auto-create folder column when a document type specifies `folder_field`
- register observer for DocumentType

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68503c3eb4188320a2366dc0c28e1124