### PR TITLE
Add file upload to licence creation

### DIFF
--- a/app/Livewire/Admin/Licence/LicenceCreate.php
+++ b/app/Livewire/Admin/Licence/LicenceCreate.php
@@ -6,9 +6,12 @@ use App\Models\Licence;
 use App\Models\Company;
 use App\Models\Bivac;
 use Livewire\Component;
+use Livewire\WithFileUploads;
+use App\Models\LicenceFile;
 
 class LicenceCreate extends Component
 {
+    use WithFileUploads;
     // Champs de formulaire
     public $license_number;
     public $license_type;
@@ -26,6 +29,9 @@ class LicenceCreate extends Component
     public $cif_amount;
 
     public $payment_mode;
+
+    // Fichier de la licence
+    public $file;
 
     // BIVAC associé
     public $bivac_id;
@@ -52,13 +58,14 @@ class LicenceCreate extends Component
         'payment_mode' => 'nullable|string',
         'company_id' => 'required|exists:companies,id',
         'bivac_id' => 'nullable|exists:bivacs,id',
+        'file' => 'nullable|file|max:10240',
     ];
 
     public function save()
     {
         $this->validate();
 
-        Licence::create([
+        $licence = Licence::create([
             'license_number' => $this->license_number,
             'license_type' => $this->license_type,
             'license_category' => $this->license_category,
@@ -82,6 +89,14 @@ class LicenceCreate extends Component
             'company_id' => $this->company_id,
             'bivac_id' => $this->bivac_id,
         ]);
+
+        if ($this->file) {
+            $storedPath = $this->file->store('licence_files', 'public');
+            $licence->files()->create([
+                'name' => $this->file->getClientOriginalName(),
+                'path' => $storedPath,
+            ]);
+        }
 
         session()->flash('success', 'Licence enregistrée avec succès.');
         $this->reset();

--- a/resources/views/livewire/admin/licence/licence-create.blade.php
+++ b/resources/views/livewire/admin/licence/licence-create.blade.php
@@ -111,6 +111,13 @@
                             <x-forms.input label="Autres frais" type="number" model="other_fees" />
                             <x-forms.input label="Montant CIF" type="number" model="cif_amount" />
                             <x-forms.input label="Mode de paiement" model="payment_mode" />
+                            <div class="sm:col-span-2">
+                                <label class="mb-1.5 block text-sm font-medium text-gray-700 dark:text-gray-400">
+                                    Licence file
+                                </label>
+                                <input type="file" wire:model="file" class="dark:bg-dark-900 shadow-theme-xs focus:border-indigo-300 focus:ring-indigo-500/10 dark:focus:border-indigo-800 h-11 w-full rounded-lg border border-gray-300 bg-transparent px-4 py-2.5 text-sm text-gray-800 placeholder:text-gray-400 focus:ring-3 focus:outline-none dark:border-gray-700 dark:bg-gray-900 dark:text-white/90 dark:placeholder:text-white/30" />
+                                @error('file')<span class="text-red-500 text-sm">{{ $message }}</span>@enderror
+                            </div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- allow uploading a licence file when creating a licence

## Testing
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685167b963d483209dd101f8a4f97f49