### PR TITLE
Add tariff position to merchandise type

### DIFF
--- a/app/Livewire/Admin/ManageMerchandiseType/MerchandiseTypeCreate.php
+++ b/app/Livewire/Admin/ManageMerchandiseType/MerchandiseTypeCreate.php
@@ -11,6 +11,7 @@ class MerchandiseTypeCreate extends Component
     use WithPagination;
 
     public $name;
+    public $tariff_position;
 
     public $editingId = null;
 
@@ -22,6 +23,7 @@ class MerchandiseTypeCreate extends Component
 
     protected $rules = [
         'name' => 'required|string|min:2|max:255',
+        'tariff_position' => 'nullable|string|max:255',
     ];
 
     public function save()
@@ -30,18 +32,22 @@ class MerchandiseTypeCreate extends Component
 
         MerchandiseType::updateOrCreate(
             ['id' => $this->editingId],
-            ['name' => $this->name]
+            [
+                'name' => $this->name,
+                'tariff_position' => $this->tariff_position,
+            ]
         );
 
         session()->flash('success', 'Merchandise type '.($this->editingId ? 'updated' : 'added').' successfully.');
 
-        $this->reset(['name', 'editingId']);
+        $this->reset(['name', 'tariff_position', 'editingId']);
     }
 
     public function edit($id)
     {
         $type = MerchandiseType::findOrFail($id);
         $this->name = $type->name;
+        $this->tariff_position = $type->tariff_position;
         $this->editingId = $type->id;
     }
 
@@ -64,7 +70,7 @@ class MerchandiseTypeCreate extends Component
 
     public function resetForm()
     {
-        $this->reset(['name', 'editingId', 'search', 'confirmingReset']);
+        $this->reset(['name', 'tariff_position', 'editingId', 'search', 'confirmingReset']);
     }
 
     public function render()

--- a/app/Models/MerchandiseType.php
+++ b/app/Models/MerchandiseType.php
@@ -12,5 +12,6 @@ class MerchandiseType extends Model
     //
     protected $fillable = [
         'name',
+        'tariff_position',
     ];
 }

--- a/database/migrations/2026_01_01_000003_add_tariff_position_to_merchandise_types_table.php
+++ b/database/migrations/2026_01_01_000003_add_tariff_position_to_merchandise_types_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('merchandise_types', function (Blueprint $table) {
+            $table->string('tariff_position')->nullable()->after('name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('merchandise_types', function (Blueprint $table) {
+            $table->dropColumn('tariff_position');
+        });
+    }
+};

--- a/resources/views/livewire/admin/manage-merchandise-type/merchandise-type-create.blade.php
+++ b/resources/views/livewire/admin/manage-merchandise-type/merchandise-type-create.blade.php
@@ -21,12 +21,19 @@
                     <div class="pb-5">
                         <h4 class="mb-4 text-base font-medium text-gray-800 dark:text-white/90">📝 Type Details</h4>
                         <div class="grid grid-cols-1 gap-6 sm:grid-cols-2">
-                            <x-forms.input 
-                                label="Merchandise Type Name" 
-                                wire:model="name" 
-                                placeholder="e.g., Electronics, Furniture, etc." 
+                            <x-forms.input
+                                label="Merchandise Type Name"
+                                wire:model="name"
+                                placeholder="e.g., Electronics, Furniture, etc."
                             />
                             @error('name') <p class="text-red-500 text-xs mt-1">{{ $message }}</p> @enderror
+
+                            <x-forms.input
+                                label="Tariff Position"
+                                wire:model="tariff_position"
+                                placeholder="e.g., 8504.40"
+                            />
+                            @error('tariff_position') <p class="text-red-500 text-xs mt-1">{{ $message }}</p> @enderror
                         </div>
                     </div>
                 </div>
@@ -75,6 +82,7 @@
                 <thead class="bg-gray-100 dark:bg-gray-700">
                     <tr>
                         <th class="px-4 py-2 text-left text-gray-700 dark:text-gray-200">Name</th>
+                        <th class="px-4 py-2 text-left text-gray-700 dark:text-gray-200">Tariff Position</th>
                         <th class="px-4 py-2 text-left text-gray-700 dark:text-gray-200">Actions</th>
                     </tr>
                 </thead>
@@ -82,6 +90,7 @@
                     @forelse($types as $type)
                         <tr>
                             <td class="px-4 py-2 text-gray-900 dark:text-white">{{ $type->name }}</td>
+                            <td class="px-4 py-2 text-gray-900 dark:text-white">{{ $type->tariff_position ?? '—' }}</td>
                             <td class="px-4 py-2 flex gap-3">
                                 <x-buttons.action type="button" variant="text" wire:click="edit({{ $type->id }})">
                                     Edit
@@ -106,7 +115,7 @@
                         </tr>
                     @empty
                         <tr>
-                            <td colspan="2" class="px-4 py-4 text-gray-500 text-center">
+                            <td colspan="3" class="px-4 py-4 text-gray-500 text-center">
                                 No merchandise types found.
                             </td>
                         </tr>


### PR DESCRIPTION
## Summary
- allow tariff position when creating a merchandise type
- show tariff position in merchandise type list
- support new field on backend and database schema

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68516d8b043c8320b8b70b5753c0b26d