### PR TITLE
Add folder transaction list

### DIFF
--- a/app/Livewire/Admin/Folder/FolderTransactionIndex.php
+++ b/app/Livewire/Admin/Folder/FolderTransactionIndex.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Livewire\Admin\Folder;
+
+use Livewire\Component;
+use Livewire\WithPagination;
+use App\Models\FolderTransaction;
+
+class FolderTransactionIndex extends Component
+{
+    use WithPagination;
+
+    public function render()
+    {
+        $transactions = FolderTransaction::with('folder')->latest()->paginate(15);
+        return view('livewire.admin.folder.folder-transaction-index', [
+            'transactions' => $transactions,
+        ]);
+    }
+}

--- a/resources/views/components/partials/sidebar.blade.php
+++ b/resources/views/components/partials/sidebar.blade.php
@@ -379,6 +379,13 @@
                                             Liste comptabilité
                                         </a>
                                     </li>
+                                    <li>
+                                        <a href="{{ route('folder.transactions.index') }}" class="menu-dropdown-item group"
+                                            :class="page === 'folderTransactions' ? 'menu-dropdown-item-active' :
+                                                'menu-dropdown-item-inactive'">
+                                            Transactions dossiers
+                                        </a>
+                                    </li>
                                 </ul>
                             </div>
                             <!-- Dropdown Menu End -->

--- a/resources/views/livewire/admin/folder/folder-transaction-index.blade.php
+++ b/resources/views/livewire/admin/folder/folder-transaction-index.blade.php
@@ -1,0 +1,34 @@
+<div class="bg-white dark:bg-gray-900 p-6 rounded-xl shadow">
+    <h2 class="text-lg font-semibold mb-4">Transactions des dossiers</h2>
+
+    <table class="min-w-full divide-y divide-gray-200 text-sm">
+        <thead class="bg-gray-50 dark:bg-gray-800">
+            <tr>
+                <th class="px-3 py-2 text-left">Dossier</th>
+                <th class="px-3 py-2 text-left">Date</th>
+                <th class="px-3 py-2 text-left">Libellé</th>
+                <th class="px-3 py-2 text-right">Montant</th>
+                <th class="px-3 py-2 text-left">Type</th>
+            </tr>
+        </thead>
+        <tbody class="bg-white dark:bg-gray-900 divide-y divide-gray-200">
+            @foreach($transactions as $transaction)
+                <tr>
+                    <td class="px-3 py-2">
+                        <a href="{{ route('folder.show', $transaction->folder_id) }}" class="text-indigo-600 hover:underline">
+                            {{ $transaction->folder->folder_number ?? '#' . $transaction->folder_id }}
+                        </a>
+                    </td>
+                    <td class="px-3 py-2">{{ optional($transaction->transaction_date)->format('d/m/Y') }}</td>
+                    <td class="px-3 py-2">{{ $transaction->label }}</td>
+                    <td class="px-3 py-2 text-right">{{ number_format($transaction->amount, 2, ',', ' ') }}</td>
+                    <td class="px-3 py-2">{{ $transaction->type === 'income' ? 'Perçu' : 'Dépense' }}</td>
+                </tr>
+            @endforeach
+        </tbody>
+    </table>
+
+    <div class="mt-4">
+        {{ $transactions->links('vendor.pagination.tailwind') }}
+    </div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -90,6 +90,7 @@ Route::get('/notifications/latest', [NotificationController::class, 'latest'])->
         Route::get('/list', FolderList::class)->name('list');
         Route::get('/show/{id}', FolderShow::class)->name('show');
         Route::get('/{folder}/transactions', \App\Livewire\Admin\Folder\FolderTransactions::class)->name('transactions');
+        Route::get('/transactions', \App\Livewire\Admin\Folder\FolderTransactionIndex::class)->name('transactions.index');
         Route::get('/delete/{id}', FolderCreate::class)->name('delete');
         Route::get('/restore/{id}', FolderCreate::class)->name('restore');
     });


### PR DESCRIPTION
## Summary
- show dossier transaction list via new Livewire component
- add route `/folder/transactions`
- expose transaction list in sidebar navigation

## Testing
- `npm test` *(fails: Missing script)*
- `composer test` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68517083e9c08320bbe277358df9b59a