### PR TITLE
Improve global invoice details

### DIFF
--- a/resources/views/livewire/admin/invoices/global-invoice-show.blade.php
+++ b/resources/views/livewire/admin/invoices/global-invoice-show.blade.php
@@ -65,40 +65,46 @@
                 </div>
 
                 <h3 class="text-xl font-semibold text-gray-700 mb-4 pt-4 border-t">Détails des Lignes de Facture Globale</h3>
-                <div class="overflow-x-auto">
-                    <table class="min-w-full divide-y divide-gray-200">
-                        <thead class="bg-gray-50">
-                            <tr>
-                                <th class="px-4 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Description</th>
-                                <th class="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Quantité</th>
-                                <th class="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Prix Unitaire</th>
-                                <th class="px-4 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Prix Total</th>
-                            </tr>
-                        </thead>
-                        <tbody class="bg-white divide-y divide-gray-200">
-                            @forelse ($globalInvoice->globalInvoiceItems as $item)
-                                <tr wire:key="item-{{ $item->id }}">
-                                    <td class="px-4 py-4 whitespace-normal text-sm text-gray-800">{{ $item->description }}</td>
-                                    <td class="px-4 py-4 whitespace-nowrap text-sm text-gray-500 text-right">{{ number_format($item->quantity, 2) }}</td>
-                                    <td class="px-4 py-4 whitespace-nowrap text-sm text-gray-500 text-right">{{ number_format($item->unit_price, 2) }}</td>
-                                    <td class="px-4 py-4 whitespace-nowrap text-sm text-gray-800 text-right font-medium">{{ number_format($item->total_price, 2) }}</td>
-                                </tr>
-                            @empty
-                                <tr>
-                                    <td colspan="4" class="px-6 py-12 text-center text-sm text-gray-500">
-                                        Aucun article trouvé pour cette facture globale.
-                                    </td>
-                                </tr>
-                            @endforelse
-                        </tbody>
-                        <tfoot>
-                            <tr>
-                                <td colspan="3" class="px-4 py-3 text-right text-sm font-semibold text-gray-700 uppercase">Total Général :</td>
-                                <td class="px-4 py-3 text-right text-sm font-bold text-gray-800">
-                                    {{ number_format($globalInvoice->total_amount, 2) }} {{-- Devise --}}
-                                </td>
-                            </tr>
-                        </tfoot>
+                @foreach(['import_tax' => 'A. IMPORT DUTY & TAXES', 'agency_fee' => 'B. AGENCY FEES', 'extra_fee' => 'C. AUTRES FRAIS'] as $cat => $label)
+                    @php $items = $globalInvoice->globalInvoiceItems->where('category', $cat); @endphp
+                    @if($items->count())
+                        <div class="overflow-x-auto border-t pt-4">
+                            <h2 class="text-lg font-semibold mb-2">{{ $label }}</h2>
+                            <table class="min-w-full text-sm border border-gray-200 mb-2">
+                                <thead class="bg-gray-50">
+                                    <tr>
+                                        <th class="border px-2 py-1">Réf.</th>
+                                        <th class="border px-2 py-1">Libellé</th>
+                                        <th class="border px-2 py-1 text-right">Qté</th>
+                                        <th class="border px-2 py-1 text-right">P.U (USD)</th>
+                                        <th class="border px-2 py-1 text-right">Total (USD)</th>
+                                    </tr>
+                                </thead>
+                                <tbody>
+                                    @foreach($items as $item)
+                                        <tr>
+                                            <td class="border px-2 py-1">{{ $item->ref_code }}</td>
+                                            <td class="border px-2 py-1">{{ $item->description }}</td>
+                                            <td class="border px-2 py-1 text-right">{{ number_format($item->quantity, 2) }}</td>
+                                            <td class="border px-2 py-1 text-right">{{ number_format($item->unit_price, 2) }}</td>
+                                            <td class="border px-2 py-1 text-right">{{ number_format($item->total_price, 2) }}</td>
+                                        </tr>
+                                    @endforeach
+                                    <tr>
+                                        <td colspan="4" class="border px-2 py-1 text-right font-semibold">Sous-total</td>
+                                        <td class="border px-2 py-1 text-right font-semibold">{{ number_format($items->sum('total_price'), 2) }}</td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
+                    @endif
+                @endforeach
+                <div class="border-t pt-4">
+                    <table class="w-full text-sm">
+                        <tr>
+                            <td class="text-right font-semibold pr-4">Total Général (USD) :</td>
+                            <td class="text-right font-bold text-lg text-gray-800">{{ number_format($globalInvoice->total_amount, 2) }}</td>
+                        </tr>
                     </table>
                 </div>
 

--- a/resources/views/pdf/global_invoice.blade.php
+++ b/resources/views/pdf/global_invoice.blade.php
@@ -85,27 +85,43 @@
 
     {{-- DÉTAILS DE LA FACTURE GLOBALE --}}
     <h4 style="border-top: 1px solid #000;">DÉTAILS FACTURE GLOBALE</h4>
+    @foreach(['import_tax' => 'A. IMPORT DUTY & TAXES', 'agency_fee' => 'B. AGENCY FEES', 'extra_fee' => 'C. AUTRES FRAIS'] as $cat => $label)
+        @php $items = $globalInvoice->globalInvoiceItems->where('category', $cat); @endphp
+        @if($items->count())
+            <h5 style="margin-top: 4px;">{{ $label }}</h5>
+            <table>
+                <thead>
+                    <tr>
+                        <th style="width: 15%;">RÉF.</th>
+                        <th style="width: 45%;">LIBELLÉ</th>
+                        <th style="width: 10%;" class="right">QTÉ</th>
+                        <th style="width: 15%;" class="right">P.U</th>
+                        <th style="width: 15%;" class="right">TOTAL</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach($items as $item)
+                        <tr>
+                            <td>{{ $item->ref_code }}</td>
+                            <td>{{ $item->description }}</td>
+                            <td class="right">{{ number_format($item->quantity, 2) }}</td>
+                            <td class="right">{{ number_format($item->unit_price, 2) }}</td>
+                            <td class="right">{{ number_format($item->total_price, 2) }}</td>
+                        </tr>
+                    @endforeach
+                    <tr>
+                        <td colspan="4" class="right"><strong>Sous-total</strong></td>
+                        <td class="right"><strong>{{ number_format($items->sum('total_price'), 2) }}</strong></td>
+                    </tr>
+                </tbody>
+            </table>
+        @endif
+    @endforeach
     <table>
-        <thead>
-            <tr>
-                <th style="width: 15%;">FACTURE N°</th>
-                <th style="width: 60%;">DESCRIPTION</th>
-                <th class="right" style="width: 25%;">MONTANT (USD)</th>
-            </tr>
-        </thead>
-        <tbody>
-            @foreach ($globalInvoice->globalInvoiceItems as $item)
-                <tr>
-                    <td>{{ $item->original_invoice_number }}</td>
-                    <td>{{ $item->description }}</td>
-                    <td class="right">{{ number_format($item->total_price, 2) }}</td>
-                </tr>
-            @endforeach
-            <tr>
-                <td colspan="2" class="right"><strong>Total général</strong></td>
-                <td class="right"><strong>{{ number_format($globalInvoice->total_amount, 2) }} USD</strong></td>
-            </tr>
-        </tbody>
+        <tr>
+            <td colspan="4" class="right"><strong>Total général</strong></td>
+            <td class="right"><strong>{{ number_format($globalInvoice->total_amount, 2) }} USD</strong></td>
+        </tr>
     </table>
 
     <p class="right" style="margin-top: 10px;">CHRISTELLE NTANGA<br><strong>RESP FACTURATION</strong></p>


### PR DESCRIPTION
## Summary
- add reference accessor for global invoice items
- group global invoice items by category with quantity and totals
- update PDF view to include reference, quantity and totals

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851b5285c588320aa97924b9d31da47