### PR TITLE
Add invoice group summary

### DIFF
--- a/resources/views/livewire/admin/invoices/global-invoice-show.blade.php
+++ b/resources/views/livewire/admin/invoices/global-invoice-show.blade.php
@@ -65,6 +65,27 @@
                 </div>
 
                 <h3 class="text-xl font-semibold text-gray-700 mb-4 pt-4 border-t">Détails des Lignes de Facture Globale</h3>
+                @php
+                    $folders = $globalInvoice->invoices->load('folder')->pluck('folder')->filter();
+                    $declarationCount = $folders->filter(fn($f) => !empty($f->declaration_number))->unique('declaration_number')->count();
+                    $truckCount = $folders->filter(fn($f) => !empty($f->truck_number))->unique('truck_number')->count();
+                    $scelleItem = $globalInvoice->globalInvoiceItems->first(fn($i) => str_contains(strtolower($i->description), 'scelle'));
+                    $nacItem = $globalInvoice->globalInvoiceItems->first(fn($i) => str_contains(strtolower($i->description), 'nac'));
+                @endphp
+                <table class="min-w-full text-sm border border-gray-200 mb-4">
+                    <tr class="bg-gray-50">
+                        <th class="border px-2 py-1">Déclaration</th>
+                        <th class="border px-2 py-1">Truck</th>
+                        <th class="border px-2 py-1">Scellés</th>
+                        <th class="border px-2 py-1">NAC</th>
+                    </tr>
+                    <tr>
+                        <td class="border px-2 py-1 text-center">{{ $declarationCount }}</td>
+                        <td class="border px-2 py-1 text-center">{{ $truckCount }}</td>
+                        <td class="border px-2 py-1 text-center">{{ $scelleItem?->quantity ?? 0 }} ({{ number_format($scelleItem->total_price ?? 0, 2) }} USD)</td>
+                        <td class="border px-2 py-1 text-center">{{ $nacItem?->quantity ?? 0 }} ({{ number_format($nacItem->total_price ?? 0, 2) }} USD)</td>
+                    </tr>
+                </table>
                 @foreach(['import_tax' => 'A. IMPORT DUTY & TAXES', 'agency_fee' => 'B. AGENCY FEES', 'extra_fee' => 'C. AUTRES FRAIS'] as $cat => $label)
                     @php $items = $globalInvoice->globalInvoiceItems->where('category', $cat); @endphp
                     @if($items->count())

--- a/resources/views/pdf/global_invoice.blade.php
+++ b/resources/views/pdf/global_invoice.blade.php
@@ -103,6 +103,21 @@
 
     {{-- DÉTAILS DE LA FACTURE GLOBALE --}}
     <h4 style="border-top: 1px solid #000;">DÉTAILS FACTURE GLOBALE</h4>
+    @php
+        $folders = $globalInvoice->invoices->load('folder')->pluck('folder')->filter();
+        $declarationCount = $folders->filter(fn($f) => !empty($f->declaration_number))->unique('declaration_number')->count();
+        $truckCount = $folders->filter(fn($f) => !empty($f->truck_number))->unique('truck_number')->count();
+        $scelleItem = $globalInvoice->globalInvoiceItems->first(fn($i) => str_contains(strtolower($i->description), 'scelle'));
+        $nacItem = $globalInvoice->globalInvoiceItems->first(fn($i) => str_contains(strtolower($i->description), 'nac'));
+    @endphp
+    <table class="no-border" style="margin-bottom: 4px;">
+        <tr>
+            <td><strong>Déclaration:</strong> {{ $declarationCount }}</td>
+            <td><strong>Truck:</strong> {{ $truckCount }}</td>
+            <td><strong>Scellés:</strong> {{ $scelleItem?->quantity ?? 0 }} ({{ number_format($scelleItem->total_price ?? 0, 2) }} USD)</td>
+            <td><strong>NAC:</strong> {{ $nacItem?->quantity ?? 0 }} ({{ number_format($nacItem->total_price ?? 0, 2) }} USD)</td>
+        </tr>
+    </table>
     @foreach(['import_tax' => 'A. IMPORT DUTY & TAXES', 'agency_fee' => 'B. AGENCY FEES', 'extra_fee' => 'C. AUTRES FRAIS'] as $cat => $label)
         @php $items = $globalInvoice->globalInvoiceItems->where('category', $cat); @endphp
         @if($items->count())


### PR DESCRIPTION
## Summary
- show counts of declarations, trucks, scellés and NAC values on the global invoice PDF
- display the same summary on the global invoice view in the admin

## Testing
- `php artisan test` *(fails: command not found)*
- `phpunit` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685264a09f1083209c50490ce3ec483a