### PR TITLE
Fix declaration count in global invoice

### DIFF
--- a/resources/views/livewire/admin/invoices/global-invoice-show.blade.php
+++ b/resources/views/livewire/admin/invoices/global-invoice-show.blade.php
@@ -67,7 +67,7 @@
                 <h3 class="text-xl font-semibold text-gray-700 mb-4 pt-4 border-t">Détails des Lignes de Facture Globale</h3>
                 @php
                     $folders = $globalInvoice->invoices->load('folder')->pluck('folder')->filter();
-                    $declarationCount = $folders->filter(fn($f) => !empty($f->declaration_number))->unique('declaration_number')->count();
+                    $declarationCount = $folders->filter(fn($f) => !empty($f->truck_number))->count();
                     $truckCount = $folders->filter(fn($f) => !empty($f->truck_number))->unique('truck_number')->count();
                     $scelleItem = $globalInvoice->globalInvoiceItems->first(fn($i) => str_contains(strtolower($i->description), 'scelle'));
                     $nacItem = $globalInvoice->globalInvoiceItems->first(fn($i) => str_contains(strtolower($i->description), 'nac'));

--- a/resources/views/pdf/global_invoice.blade.php
+++ b/resources/views/pdf/global_invoice.blade.php
@@ -106,7 +106,7 @@
     <h4 style="border-top: 1px solid #000; margin-bottom: 8px;">DÉTAILS FACTURE GLOBALE</h4>
     @php
         $folders = $globalInvoice->invoices->load('folder')->pluck('folder')->filter();
-        $declarationCount = $folders->filter(fn($f) => !empty($f->declaration_number))->unique('declaration_number')->count();
+        $declarationCount = $folders->filter(fn($f) => !empty($f->truck_number))->count();
         $truckCount = $folders->filter(fn($f) => !empty($f->truck_number))->unique('truck_number')->count();
         $scelleItem = $globalInvoice->globalInvoiceItems->first(fn($i) => str_contains(strtolower($i->description), 'scelle'));
         $nacItem = $globalInvoice->globalInvoiceItems->first(fn($i) => str_contains(strtolower($i->description), 'nac'));


### PR DESCRIPTION
## Summary
- show declaration total equal to total trucks in global invoice view and PDF

## Testing
- `./vendor/bin/pest` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68526cfbc1108320bca77c99dc50b322