### PR TITLE
Fix void method returning a redirect

### DIFF
--- a/app/Livewire/Admin/Invoices/UpdateInvoice.php
+++ b/app/Livewire/Admin/Invoices/UpdateInvoice.php
@@ -171,7 +171,7 @@ class UpdateInvoice extends Component
     {
         $this->invoice->update(['status' => 'approved']);
         session()->flash('success', 'Facture validée avec succès.');
-        return redirect()->route('invoices.show', $this->invoice->id);
+        redirect()->route('invoices.show', $this->invoice->id);
     }
     public function render()
     {


### PR DESCRIPTION
## Summary
- do not return a value from `validateInvoice()`

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852c41c8fec8320ac174aa72cbaa14a