### PR TITLE
Improve audit log details

### DIFF
--- a/app/Models/AuditLog.php
+++ b/app/Models/AuditLog.php
@@ -20,4 +20,20 @@ class AuditLog extends Model
     {
         return $this->belongsTo(User::class);
     }
+
+    /**
+     * Retrieve a human-friendly identifier for the audited model.
+     */
+    public function getIdentifierAttribute(): string
+    {
+        $data = $this->new_data ?: $this->previous_data ?: [];
+
+        foreach (['folder_number', 'invoice_number', 'operation_code', 'name', 'label', 'title'] as $field) {
+            if (isset($data[$field]) && $data[$field] !== '') {
+                return (string) $data[$field];
+            }
+        }
+
+        return (string) $this->auditable_id;
+    }
 }

--- a/app/Observers/AuditObserver.php
+++ b/app/Observers/AuditObserver.php
@@ -7,6 +7,17 @@ use Illuminate\Support\Facades\Auth;
 
 class AuditObserver
 {
+    private function getLabel($model): string
+    {
+        foreach (['folder_number', 'invoice_number', 'operation_code', 'name', 'label', 'title'] as $field) {
+            if (isset($model->{$field}) && $model->{$field} !== '') {
+                return (string) $model->{$field};
+            }
+        }
+
+        return (string) $model->id;
+    }
+
     /**
      * Enregistre l’audit lors de la création d’un modèle.
      */
@@ -19,7 +30,7 @@ class AuditObserver
             'operation' => 'CREATE',
             'previous_data' => null,
             'new_data' => $model->toArray(),
-            'message' => 'Création de '.class_basename($model),
+            'message' => 'Création de '.class_basename($model).' ('.$this->getLabel($model).')',
         ]);
     }
 
@@ -35,7 +46,7 @@ class AuditObserver
             'operation' => 'UPDATE',
             'previous_data' => $model->getOriginal(),
             'new_data' => $model->toArray(),
-            'message' => 'Mise à jour de '.class_basename($model),
+            'message' => 'Mise à jour de '.class_basename($model).' ('.$this->getLabel($model).')',
         ]);
     }
 
@@ -51,7 +62,7 @@ class AuditObserver
             'operation' => 'DELETE',
             'previous_data' => $model->toArray(),
             'new_data' => null,
-            'message' => 'Suppression de '.class_basename($model),
+            'message' => 'Suppression de '.class_basename($model).' ('.$this->getLabel($model).')',
         ]);
     }
 }

--- a/resources/views/livewire/admin/audit/audit-log-index.blade.php
+++ b/resources/views/livewire/admin/audit/audit-log-index.blade.php
@@ -12,6 +12,7 @@
                 <th class="border px-2 py-1">Utilisateur</th>
                 <th class="border px-2 py-1">Opération</th>
                 <th class="border px-2 py-1">Modèle</th>
+                <th class="border px-2 py-1">Référence</th>
                 <th class="border px-2 py-1">Message</th>
             </tr>
         </thead>
@@ -22,11 +23,12 @@
                     <td class="border px-2 py-1">{{ optional($log->user)->name ?? 'System' }}</td>
                     <td class="border px-2 py-1">{{ $log->operation }}</td>
                     <td class="border px-2 py-1">{{ class_basename($log->auditable_type) }}</td>
+                    <td class="border px-2 py-1">{{ $log->identifier }}</td>
                     <td class="border px-2 py-1">{{ $log->message }}</td>
                 </tr>
             @empty
                 <tr>
-                    <td colspan="5" class="border px-2 py-1 text-center">Aucun log</td>
+                    <td colspan="6" class="border px-2 py-1 text-center">Aucun log</td>
                 </tr>
             @endforelse
         </tbody>


### PR DESCRIPTION
## Summary
- include helpful model identifier in audit messages
- expose identifier attribute on `AuditLog`
- show identifier column in audit log view

## Testing
- `php artisan test --parallel --processes=2` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852c987a65883208b1764b231b78b8c