### PR TITLE
Improve invoice edit validation

### DIFF
--- a/app/Livewire/Admin/Invoices/UpdateInvoice.php
+++ b/app/Livewire/Admin/Invoices/UpdateInvoice.php
@@ -20,6 +20,29 @@ class UpdateInvoice extends Component
 
     public $taxes = [], $agencyFees = [], $extraFees = [];
 
+    protected function rules()
+    {
+        return [
+            'company_id' => 'required|integer|exists:companies,id',
+            'invoice_date' => 'required|date',
+            'product' => 'required|string|max:255',
+            'weight' => 'nullable|numeric',
+            'operation_code' => 'nullable|string|max:255',
+            'fob_amount' => 'required|numeric|min:0',
+            'insurance_amount' => 'nullable|numeric|min:0',
+            'freight_amount' => 'nullable|numeric|min:0',
+            'cif_amount' => 'nullable|numeric|min:0',
+            'payment_mode' => 'required|string',
+            'items' => 'present|array|min:1',
+            'items.*.label' => 'nullable|string|max:255',
+            'items.*.amount_usd' => 'required|numeric|min:0',
+            'items.*.category' => 'required|in:import_tax,agency_fee,extra_fee',
+            'items.*.tax_id' => 'nullable|integer|exists:taxes,id',
+            'items.*.agency_fee_id' => 'nullable|integer|exists:agency_fees,id',
+            'items.*.extra_fee_id' => 'nullable|integer|exists:extra_fees,id',
+        ];
+    }
+
     public function mount(Invoice $invoice)
     {
         $this->invoice = $invoice;
@@ -134,21 +157,41 @@ class UpdateInvoice extends Component
 
     public function updateInvoice()
     {
+        $validated = $this->validate();
+
+        foreach ($validated['items'] as $index => $item) {
+            if ($item['category'] === 'import_tax' && empty($item['tax_id'])) {
+                $this->addError("items.{$index}.tax_id", 'Le champ Taxe est requis.');
+            }
+            if ($item['category'] === 'agency_fee' && empty($item['agency_fee_id'])) {
+                $this->addError("items.{$index}.agency_fee_id", 'Le champ Frais agence est requis.');
+            }
+            if ($item['category'] === 'extra_fee' && empty($item['extra_fee_id'])) {
+                $this->addError("items.{$index}.extra_fee_id", 'Le champ Frais divers est requis.');
+            }
+        }
+
+        if ($this->getErrorBag()->isNotEmpty()) {
+            return;
+        }
+
+        $totalUsd = collect($validated['items'])->sum('amount_usd');
+
         $this->invoice->update([
-            'company_id' => $this->company_id,
-            'invoice_date' => $this->invoice_date,
-            'product' => $this->product,
-            'weight' => $this->weight,
-            'operation_code' => $this->operation_code,
-            'fob_amount' => $this->fob_amount,
-            'insurance_amount' => $this->insurance_amount,
-            'freight_amount' => $this->freight_amount,
-            'cif_amount' => $this->cif_amount,
-            'payment_mode' => $this->payment_mode,
-            'total_usd' => $this->total_usd,
+            'company_id' => $validated['company_id'],
+            'invoice_date' => $validated['invoice_date'],
+            'product' => $validated['product'],
+            'weight' => $validated['weight'],
+            'operation_code' => $validated['operation_code'],
+            'fob_amount' => $validated['fob_amount'],
+            'insurance_amount' => $validated['insurance_amount'],
+            'freight_amount' => $validated['freight_amount'],
+            'cif_amount' => $validated['cif_amount'],
+            'payment_mode' => $validated['payment_mode'],
+            'total_usd' => $totalUsd,
         ]);
 
-        foreach ($this->items as $item) {
+        foreach ($validated['items'] as $item) {
             InvoiceItem::updateOrCreate(
                 ['id' => $item['item_id'] ?? null],
                 [
@@ -169,6 +212,16 @@ class UpdateInvoice extends Component
 
     public function validateInvoice(): void
     {
+        if ($this->invoice->status === 'approved') {
+            session()->flash('success', 'Cette facture est déjà validée.');
+            return;
+        }
+
+        if ($this->invoice->items()->count() === 0) {
+            session()->flash('error', 'Impossible de valider une facture sans lignes.');
+            return;
+        }
+
         $this->invoice->update(['status' => 'approved']);
         session()->flash('success', 'Facture validée avec succès.');
         redirect()->route('invoices.show', $this->invoice->id);


### PR DESCRIPTION
## Summary
- add validation rules for editing invoices
- validate item fields before saving
- prevent validating an already approved invoice

## Testing
- `./vendor/bin/pest` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6852ccebc9488320a536253fc17d1e00