### PR TITLE
Add module to manage invoice items

### DIFF
--- a/app/Livewire/Admin/Invoices/AddInvoiceItems.php
+++ b/app/Livewire/Admin/Invoices/AddInvoiceItems.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace App\Livewire\Admin\Invoices;
+
+use Livewire\Component;
+use App\Models\Invoice;
+use App\Models\InvoiceItem;
+use App\Models\Tax;
+use App\Models\AgencyFee;
+use App\Models\ExtraFee;
+
+class AddInvoiceItems extends Component
+{
+    public Invoice $invoice;
+
+    public array $taxItems = [];
+    public array $agencyFeeItems = [];
+    public array $extraFeeItems = [];
+
+    public $taxes = [];
+    public $agencyFees = [];
+    public $extraFees = [];
+
+    public function mount(Invoice $invoice)
+    {
+        $this->invoice = $invoice->load('items');
+        $this->taxes = Tax::orderBy('label')->get();
+        $this->agencyFees = AgencyFee::orderBy('label')->get();
+        $this->extraFees = ExtraFee::orderBy('label')->get();
+    }
+
+    public function addTaxItem(): void
+    {
+        $this->taxItems[] = ['tax_id' => null, 'amount_usd' => 0];
+    }
+
+    public function addAgencyFeeItem(): void
+    {
+        $this->agencyFeeItems[] = ['agency_fee_id' => null, 'amount_usd' => 0];
+    }
+
+    public function addExtraFeeItem(): void
+    {
+        $this->extraFeeItems[] = ['extra_fee_id' => null, 'amount_usd' => 0];
+    }
+
+    public function removeItem(string $group, int $index): void
+    {
+        if ($group === 'tax') {
+            unset($this->taxItems[$index]);
+            $this->taxItems = array_values($this->taxItems);
+        } elseif ($group === 'agency') {
+            unset($this->agencyFeeItems[$index]);
+            $this->agencyFeeItems = array_values($this->agencyFeeItems);
+        } elseif ($group === 'extra') {
+            unset($this->extraFeeItems[$index]);
+            $this->extraFeeItems = array_values($this->extraFeeItems);
+        }
+    }
+
+    public function save(): void
+    {
+        $this->validate([
+            'taxItems.*.tax_id' => 'required|exists:taxes,id',
+            'taxItems.*.amount_usd' => 'required|numeric|min:0',
+            'agencyFeeItems.*.agency_fee_id' => 'required|exists:agency_fees,id',
+            'agencyFeeItems.*.amount_usd' => 'required|numeric|min:0',
+            'extraFeeItems.*.extra_fee_id' => 'required|exists:extra_fees,id',
+            'extraFeeItems.*.amount_usd' => 'required|numeric|min:0',
+        ]);
+
+        foreach ($this->taxItems as $item) {
+            $label = Tax::find($item['tax_id'])?->label;
+            $this->invoice->items()->create([
+                'label' => $label,
+                'category' => 'import_tax',
+                'amount_usd' => $item['amount_usd'],
+                'tax_id' => $item['tax_id'],
+            ]);
+        }
+
+        foreach ($this->agencyFeeItems as $item) {
+            $label = AgencyFee::find($item['agency_fee_id'])?->label;
+            $this->invoice->items()->create([
+                'label' => $label,
+                'category' => 'agency_fee',
+                'amount_usd' => $item['amount_usd'],
+                'agency_fee_id' => $item['agency_fee_id'],
+            ]);
+        }
+
+        foreach ($this->extraFeeItems as $item) {
+            $label = ExtraFee::find($item['extra_fee_id'])?->label;
+            $this->invoice->items()->create([
+                'label' => $label,
+                'category' => 'extra_fee',
+                'amount_usd' => $item['amount_usd'],
+                'extra_fee_id' => $item['extra_fee_id'],
+            ]);
+        }
+
+        $this->invoice->total_usd = $this->invoice->items()->sum('amount_usd');
+        $this->invoice->save();
+
+        session()->flash('success', 'Éléments ajoutés à la facture.');
+        redirect()->route('invoices.show', $this->invoice->id);
+    }
+
+    public function render()
+    {
+        return view('livewire.admin.invoices.add-invoice-items');
+    }
+}

--- a/database/factories/AgencyFeeFactory.php
+++ b/database/factories/AgencyFeeFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\AgencyFee;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class AgencyFeeFactory extends Factory
+{
+    protected $model = AgencyFee::class;
+
+    public function definition()
+    {
+        return [
+            'code' => $this->faker->unique()->lexify('AGE-???'),
+            'label' => $this->faker->words(3, true),
+        ];
+    }
+}

--- a/database/factories/ExtraFeeFactory.php
+++ b/database/factories/ExtraFeeFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\ExtraFee;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ExtraFeeFactory extends Factory
+{
+    protected $model = ExtraFee::class;
+
+    public function definition()
+    {
+        return [
+            'code' => $this->faker->unique()->lexify('EX-???'),
+            'label' => $this->faker->words(3, true),
+        ];
+    }
+}

--- a/database/factories/TaxFactory.php
+++ b/database/factories/TaxFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Tax;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class TaxFactory extends Factory
+{
+    protected $model = Tax::class;
+
+    public function definition()
+    {
+        return [
+            'code' => $this->faker->unique()->lexify('TAX-???'),
+            'label' => $this->faker->words(3, true),
+        ];
+    }
+}

--- a/resources/views/livewire/admin/invoices/add-invoice-items.blade.php
+++ b/resources/views/livewire/admin/invoices/add-invoice-items.blade.php
@@ -1,0 +1,46 @@
+<div class="max-w-4xl mx-auto space-y-6">
+    <x-ui.flash-message />
+    <x-ui.error-message />
+
+    <h2 class="text-xl font-bold">Ajouter des éléments à la facture {{ $invoice->invoice_number }}</h2>
+
+    <div class="bg-white dark:bg-gray-800 shadow rounded-xl p-6 space-y-4 border border-gray-200 dark:border-gray-700">
+        <h3 class="text-lg font-semibold">Taxes</h3>
+        @foreach($taxItems as $i => $item)
+            <div class="grid grid-cols-3 gap-2 items-end">
+                <x-forms.select label="Taxe" :model="'taxItems.' . $i . '.tax_id'" :options="$taxes" optionLabel="label" optionValue="id" />
+                <x-forms.input label="Montant USD" type="number" step="0.01" :model="'taxItems.' . $i . '.amount_usd'" />
+                <button type="button" wire:click="removeItem('tax', {{ $i }})" class="text-red-600 text-sm">❌</button>
+            </div>
+        @endforeach
+        <button type="button" wire:click="addTaxItem" class="text-sm text-blue-600 hover:underline">➕ Ajouter une taxe</button>
+    </div>
+
+    <div class="bg-white dark:bg-gray-800 shadow rounded-xl p-6 space-y-4 border border-gray-200 dark:border-gray-700">
+        <h3 class="text-lg font-semibold">Frais agence</h3>
+        @foreach($agencyFeeItems as $i => $item)
+            <div class="grid grid-cols-3 gap-2 items-end">
+                <x-forms.select label="Frais agence" :model="'agencyFeeItems.' . $i . '.agency_fee_id'" :options="$agencyFees" optionLabel="label" optionValue="id" />
+                <x-forms.input label="Montant USD" type="number" step="0.01" :model="'agencyFeeItems.' . $i . '.amount_usd'" />
+                <button type="button" wire:click="removeItem('agency', {{ $i }})" class="text-red-600 text-sm">❌</button>
+            </div>
+        @endforeach
+        <button type="button" wire:click="addAgencyFeeItem" class="text-sm text-blue-600 hover:underline">➕ Ajouter un frais agence</button>
+    </div>
+
+    <div class="bg-white dark:bg-gray-800 shadow rounded-xl p-6 space-y-4 border border-gray-200 dark:border-gray-700">
+        <h3 class="text-lg font-semibold">Autres frais</h3>
+        @foreach($extraFeeItems as $i => $item)
+            <div class="grid grid-cols-3 gap-2 items-end">
+                <x-forms.select label="Frais divers" :model="'extraFeeItems.' . $i . '.extra_fee_id'" :options="$extraFees" optionLabel="label" optionValue="id" />
+                <x-forms.input label="Montant USD" type="number" step="0.01" :model="'extraFeeItems.' . $i . '.amount_usd'" />
+                <button type="button" wire:click="removeItem('extra', {{ $i }})" class="text-red-600 text-sm">❌</button>
+            </div>
+        @endforeach
+        <button type="button" wire:click="addExtraFeeItem" class="text-sm text-blue-600 hover:underline">➕ Ajouter un frais divers</button>
+    </div>
+
+    <div class="flex justify-end">
+        <x-forms.button wire:click="save">Enregistrer</x-forms.button>
+    </div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -155,6 +155,7 @@ Route::get('/notifications/latest', [NotificationController::class, 'latest'])->
         Route::get('/download/{invoice}', [ShowInvoice::class, 'downloadPdf'])->name('download');
         Route::get('/index', InvoiceIndex::class)->name('index');
         Route::get('/invoices/{invoice}/edit', UpdateInvoice::class)->name('invoices.edit');
+        Route::get('/invoices/{invoice}/items', \App\Livewire\Admin\Invoices\AddInvoiceItems::class)->name('items.add');
         Route::get('/trash', InvoiceTrash::class)->name('trash');
 
     });

--- a/tests/Feature/Admin/AddInvoiceItemsTest.php
+++ b/tests/Feature/Admin/AddInvoiceItemsTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Models\User;
+use App\Models\Company;
+use App\Models\Invoice;
+use App\Models\Tax;
+use App\Models\AgencyFee;
+use App\Models\ExtraFee;
+use App\Livewire\Admin\Invoices\AddInvoiceItems;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class AddInvoiceItemsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_items_can_be_added_to_invoice(): void
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $company = Company::factory()->create();
+        $invoice = Invoice::factory()->for($company)->create();
+
+        $tax = Tax::factory()->create();
+        $agency = AgencyFee::factory()->create();
+        $extra = ExtraFee::factory()->create();
+
+        Livewire::test(AddInvoiceItems::class, ['invoice' => $invoice->id])
+            ->set('taxItems', [['tax_id' => $tax->id, 'amount_usd' => 10]])
+            ->set('agencyFeeItems', [['agency_fee_id' => $agency->id, 'amount_usd' => 20]])
+            ->set('extraFeeItems', [['extra_fee_id' => $extra->id, 'amount_usd' => 5]])
+            ->call('save');
+
+        $this->assertDatabaseHas('invoice_items', [
+            'invoice_id' => $invoice->id,
+            'tax_id' => $tax->id,
+            'category' => 'import_tax',
+            'amount_usd' => 10,
+        ]);
+
+        $this->assertDatabaseHas('invoice_items', [
+            'invoice_id' => $invoice->id,
+            'agency_fee_id' => $agency->id,
+            'category' => 'agency_fee',
+            'amount_usd' => 20,
+        ]);
+
+        $this->assertDatabaseHas('invoice_items', [
+            'invoice_id' => $invoice->id,
+            'extra_fee_id' => $extra->id,
+            'category' => 'extra_fee',
+            'amount_usd' => 5,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add `AddInvoiceItems` Livewire component
- add blade template for invoice item form with tax, agency fee and extra fee sections
- register new factories for tax and fees
- expose route `/invoices/{invoice}/items`
- cover invoice item addition with feature test

## Testing
- `php artisan test` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852ce55760083209bc4b5940574d95f