### PR TITLE
Fix invoice items route and update button style

### DIFF
--- a/resources/views/livewire/admin/invoices/update-invoice.blade.php
+++ b/resources/views/livewire/admin/invoices/update-invoice.blade.php
@@ -43,7 +43,7 @@
 
                 <div class="flex justify-end pt-4 space-x-2">
                     <x-forms.button type="submit">Mettre à jour</x-forms.button>
-                    <button type="button" wire:click="validateInvoice" class="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700">Valider</button>
+                    <button type="button" wire:click="validateInvoice" class="px-4 py-2 text-white rounded bg-brand-500 hover:bg-brand-600">Valider</button>
                 </div>
             </div>
         </form>

--- a/routes/web.php
+++ b/routes/web.php
@@ -150,12 +150,12 @@ Route::get('/notifications/latest', [NotificationController::class, 'latest'])->
 
 
     Route::prefix('invoices')->name('invoices.')->group(function () {
-        Route::get('/invoices/{invoice}/show', ShowInvoice::class)->name('show');
+        Route::get('/{invoice}/show', ShowInvoice::class)->name('show');
         Route::get('/generate/{folder}', GenerateInvoice::class)->name('generate');
         Route::get('/download/{invoice}', [ShowInvoice::class, 'downloadPdf'])->name('download');
         Route::get('/index', InvoiceIndex::class)->name('index');
-        Route::get('/invoices/{invoice}/edit', UpdateInvoice::class)->name('invoices.edit');
-        Route::get('/invoices/{invoice}/items', \App\Livewire\Admin\Invoices\AddInvoiceItems::class)->name('items.add');
+        Route::get('/{invoice}/edit', UpdateInvoice::class)->name('invoices.edit');
+        Route::get('/{invoice}/items', \App\Livewire\Admin\Invoices\AddInvoiceItems::class)->name('items.add');
         Route::get('/trash', InvoiceTrash::class)->name('trash');
 
     });


### PR DESCRIPTION
## Summary
- correct duplicate `invoices` path when adding items
- use brand color for invoice validation button

## Testing
- `php artisan test` *(fails: `php: command not found`)*
- `vendor/bin/phpunit` *(fails: `No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_6852d1f148e08320a5a214cf98255d36