### PR TITLE
Add messages for invoice items

### DIFF
--- a/resources/views/components/ui/error-message.blade.php
+++ b/resources/views/components/ui/error-message.blade.php
@@ -1,11 +1,11 @@
 <div>
     <div class="fixed top-2 right-2 z-50">
-        @if ($errors->any())
-            <div 
-                x-data="{ show: true }" 
-                x-init="setTimeout(() => show = false, 7000)" 
-                x-show="show" 
-                x-transition 
+        @if ($errors->any() || session()->has('error'))
+            <div
+                x-data="{ show: true }"
+                x-init="setTimeout(() => show = false, 7000)"
+                x-show="show"
+                x-transition
                 class="rounded-xl border border-red-500 bg-red-50 p-4 dark:border-red-500/30 dark:bg-red-500/15 w-[400px]"
             >
                 <div class="flex items-start justify-between gap-3">
@@ -31,6 +31,9 @@
                                     <li>{{ $error }}</li>
                                 @endforeach
                             </ul>
+                            @if (session()->has('error'))
+                                <p class="text-sm text-gray-600 dark:text-gray-400 mt-2">{{ session('error') }}</p>
+                            @endif
                         </div>
                     </div>
                     <button @click="show = false" class="text-gray-400 hover:text-gray-600 dark:hover:text-white transition">

--- a/resources/views/components/ui/flash-message.blade.php
+++ b/resources/views/components/ui/flash-message.blade.php
@@ -1,18 +1,27 @@
 <div>
     <div class="fixed top-5 left-2 z-50">
         <!-- Ton code original ici, inchangé -->
-        @if (session()->has('message'))
+        @if (session()->has('message') || session()->has('success') || session()->has('error'))
+            @php
+                $type = 'success';
+                $content = session('message') ?? session('success');
+                if (session()->has('error')) {
+                    $type = 'error';
+                    $content = session('error');
+                }
+            @endphp
             <div x-data="{ show: true }" x-init="setTimeout(() => show = false, 5000)" x-show="show" x-transition
-                class="rounded-xl border border-success-500 bg-success-50 p-4 dark:border-success-500/30 dark:bg-success-500/15 mb-6 w-[400px]">
+                class="rounded-xl border border-{{ $type === 'error' ? 'red' : 'success' }}-500 bg-{{ $type === 'error' ? 'red' : 'success' }}-50 p-4 dark:border-{{ $type === 'error' ? 'red' : 'success' }}-500/30 dark:bg-{{ $type === 'error' ? 'red' : 'success' }}-500/15 mb-6 w-[400px]">
                 <div class="flex items-start justify-between gap-3">
                     <div class="flex items-start gap-3">
-                        <div class="-mt-0.5 text-success-500">
+                        <div class="-mt-0.5 text-{{ $type === 'error' ? 'red' : 'success' }}-500">
                             <!-- icône SVG ici -->
                         </div>
                         <div>
-                            <h4 class="mb-1 text-sm font-semibold text-gray-800 dark:text-white/90">Success</h4>
+                            <h4 class="mb-1 text-sm font-semibold text-gray-800 dark:text-white/90">
+                                {{ $type === 'error' ? 'Erreur' : 'Success' }}</h4>
                             <p class="text-sm text-gray-500 dark:text-gray-400">
-                                {{ session('message') }}
+                                {{ $content }}
                             </p>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- handle DB errors when adding invoice items
- show flash messages for success and errors
- display session errors using the error message component

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852d302cfc88320840f27db24f0ca5f