### PR TITLE
Improve add invoice items design

### DIFF
--- a/resources/views/livewire/admin/invoices/add-invoice-items.blade.php
+++ b/resources/views/livewire/admin/invoices/add-invoice-items.blade.php
@@ -1,29 +1,36 @@
-<div class="w-full mx-auto space-y-6">
+<div class="max-w-5xl mx-auto p-6 space-y-6">
     <x-ui.flash-message />
     <x-ui.error-message />
 
-    <h2 class="text-xl font-bold">Ajouter des éléments à la facture {{ $invoice->invoice_number }}</h2>
+    <div class="rounded-2xl border border-gray-200 bg-white dark:border-gray-800 dark:bg-white/[0.03] shadow-sm">
+        <div class="space-y-8 p-6">
+            <h2 class="text-2xl font-bold flex items-center gap-2 text-gray-800 dark:text-white">
+                🧾
+                <span>Ajouter des éléments à la facture {{ $invoice->invoice_number }}</span>
+            </h2>
 
-    <div class="bg-white dark:bg-gray-800 shadow rounded-xl p-6 space-y-4 border border-gray-200 dark:border-gray-700">
-        <h3 class="text-lg font-semibold">Taxes</h3>
-        @foreach($taxItems as $i => $item)
-            <div class="grid grid-cols-1 md:grid-cols-12 gap-4 items-end">
-                <div class="md:col-span-5">
-                    <x-forms.select label="Taxe" :model="'taxItems.' . $i . '.tax_id'" :options="$taxes" optionLabel="label" optionValue="id" />
-                </div>
+            <section class="space-y-4">
+                <h3 class="text-lg font-semibold flex items-center gap-2 text-gray-700 dark:text-gray-200">💰 Taxes</h3>
+                @foreach($taxItems as $i => $item)
+                    <div class="grid grid-cols-1 md:grid-cols-12 gap-4 items-end">
+                        <div class="md:col-span-5">
+                            <x-forms.select label="Taxe" :model="'taxItems.' . $i . '.tax_id'" :options="$taxes" optionLabel="label" optionValue="id" />
+                        </div>
                 <div class="md:col-span-5">
                     <x-forms.input label="Montant USD" type="number" step="0.01" :model="'taxItems.' . $i . '.amount_usd'" />
                 </div>
                 <div class="md:col-span-2 flex justify-end">
-                    <button type="button" wire:click="removeItem('tax', {{ $i }})" class="text-red-600 text-sm">❌</button>
+                    <button type="button" wire:click="removeItem('tax', {{ $i }})" class="text-red-600 hover:text-red-800 text-lg">❌</button>
                 </div>
             </div>
         @endforeach
-        <button type="button" wire:click="addTaxItem" class="text-sm text-blue-600 hover:underline">➕ Ajouter une taxe</button>
-    </div>
+                <button type="button" wire:click="addTaxItem" class="flex items-center text-sm text-blue-600 hover:text-blue-800 transition">
+                    ➕ <span class="ml-1">Ajouter une taxe</span>
+                </button>
+            </section>
 
-    <div class="bg-white dark:bg-gray-800 shadow rounded-xl p-6 space-y-4 border border-gray-200 dark:border-gray-700">
-        <h3 class="text-lg font-semibold">Frais agence</h3>
+            <section class="space-y-4">
+                <h3 class="text-lg font-semibold flex items-center gap-2 text-gray-700 dark:text-gray-200">🏢 Frais agence</h3>
         @foreach($agencyFeeItems as $i => $item)
             <div class="grid grid-cols-1 md:grid-cols-12 gap-4 items-end">
                 <div class="md:col-span-5">
@@ -33,15 +40,17 @@
                     <x-forms.input label="Montant USD" type="number" step="0.01" :model="'agencyFeeItems.' . $i . '.amount_usd'" />
                 </div>
                 <div class="md:col-span-2 flex justify-end">
-                    <button type="button" wire:click="removeItem('agency', {{ $i }})" class="text-red-600 text-sm">❌</button>
+                    <button type="button" wire:click="removeItem('agency', {{ $i }})" class="text-red-600 hover:text-red-800 text-lg">❌</button>
                 </div>
             </div>
         @endforeach
-        <button type="button" wire:click="addAgencyFeeItem" class="text-sm text-blue-600 hover:underline">➕ Ajouter un frais agence</button>
-    </div>
+                <button type="button" wire:click="addAgencyFeeItem" class="flex items-center text-sm text-blue-600 hover:text-blue-800 transition">
+                    ➕ <span class="ml-1">Ajouter un frais agence</span>
+                </button>
+            </section>
 
-    <div class="bg-white dark:bg-gray-800 shadow rounded-xl p-6 space-y-4 border border-gray-200 dark:border-gray-700">
-        <h3 class="text-lg font-semibold">Autres frais</h3>
+            <section class="space-y-4">
+                <h3 class="text-lg font-semibold flex items-center gap-2 text-gray-700 dark:text-gray-200">📝 Autres frais</h3>
         @foreach($extraFeeItems as $i => $item)
             <div class="grid grid-cols-1 md:grid-cols-12 gap-4 items-end">
                 <div class="md:col-span-5">
@@ -51,14 +60,18 @@
                     <x-forms.input label="Montant USD" type="number" step="0.01" :model="'extraFeeItems.' . $i . '.amount_usd'" />
                 </div>
                 <div class="md:col-span-2 flex justify-end">
-                    <button type="button" wire:click="removeItem('extra', {{ $i }})" class="text-red-600 text-sm">❌</button>
+                    <button type="button" wire:click="removeItem('extra', {{ $i }})" class="text-red-600 hover:text-red-800 text-lg">❌</button>
                 </div>
             </div>
         @endforeach
-        <button type="button" wire:click="addExtraFeeItem" class="text-sm text-blue-600 hover:underline">➕ Ajouter un frais divers</button>
-    </div>
+                <button type="button" wire:click="addExtraFeeItem" class="flex items-center text-sm text-blue-600 hover:text-blue-800 transition">
+                    ➕ <span class="ml-1">Ajouter un frais divers</span>
+                </button>
+            </section>
 
-    <div class="flex justify-end">
-        <x-forms.button wire:click="save" color="purple">Enregistrer</x-forms.button>
+            <div class="flex justify-end pt-6">
+                <x-forms.button wire:click="save" color="purple">💾 Enregistrer</x-forms.button>
+            </div>
+        </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- enhance responsive layout for adding invoice items
- use modern card-style container with icons

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853009d387083208c6bc2edbefc34f5