### PR TITLE
Prevent editing grouped invoices

### DIFF
--- a/app/Livewire/Admin/Invoices/AddInvoiceItems.php
+++ b/app/Livewire/Admin/Invoices/AddInvoiceItems.php
@@ -25,6 +25,11 @@ class AddInvoiceItems extends Component
 
     public function mount(Invoice $invoice)
     {
+        if ($invoice->global_invoice_id) {
+            session()->flash('error', "La facture {$invoice->invoice_number} est déjà incluse dans une facture globale. Impossible de la modifier.");
+            redirect()->route('invoices.show', $invoice->id);
+        }
+
         $this->invoice = $invoice->load('items');
         $this->taxes = Tax::orderBy('label')->get();
         $this->agencyFees = AgencyFee::orderBy('label')->get();

--- a/app/Livewire/Admin/Invoices/UpdateInvoice.php
+++ b/app/Livewire/Admin/Invoices/UpdateInvoice.php
@@ -22,6 +22,11 @@ class UpdateInvoice extends Component
 
     public function mount(Invoice $invoice)
     {
+        if ($invoice->global_invoice_id) {
+            session()->flash('error', "La facture {$invoice->invoice_number} est déjà incluse dans une facture globale. Impossible de la modifier.");
+            redirect()->route('invoices.show', $invoice->id);
+        }
+
         $this->invoice = $invoice;
         $this->company_id = $invoice->company_id;
         $this->invoice_date = $invoice->invoice_date->format('Y-m-d');

--- a/tests/Feature/Admin/AddInvoiceItemsTest.php
+++ b/tests/Feature/Admin/AddInvoiceItemsTest.php
@@ -56,4 +56,21 @@ class AddInvoiceItemsTest extends TestCase
             'amount_usd' => 5,
         ]);
     }
+
+    public function test_cannot_add_items_to_grouped_invoice(): void
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $company = Company::factory()->create();
+        $global = \App\Models\GlobalInvoice::factory()->for($company)->create();
+        $invoice = Invoice::factory()->for($company)->create([
+            'status' => 'grouped_in_global_invoice',
+            'global_invoice_id' => $global->id,
+        ]);
+
+        Livewire::test(AddInvoiceItems::class, ['invoice' => $invoice->id])
+            ->assertRedirect(route('invoices.show', $invoice->id))
+            ->assertSessionHas('error');
+    }
 }

--- a/tests/Feature/Admin/UpdateInvoiceAccessTest.php
+++ b/tests/Feature/Admin/UpdateInvoiceAccessTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Models\User;
+use App\Models\Company;
+use App\Models\Invoice;
+use App\Models\GlobalInvoice;
+use App\Livewire\Admin\Invoices\UpdateInvoice;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class UpdateInvoiceAccessTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_cannot_edit_grouped_invoice(): void
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $company = Company::factory()->create();
+        $global = GlobalInvoice::factory()->for($company)->create();
+        $invoice = Invoice::factory()->for($company)->create([
+            'status' => 'grouped_in_global_invoice',
+            'global_invoice_id' => $global->id,
+        ]);
+
+        Livewire::test(UpdateInvoice::class, ['invoice' => $invoice->id])
+            ->assertRedirect(route('invoices.show', $invoice->id))
+            ->assertSessionHas('error');
+    }
+}


### PR DESCRIPTION
## Summary
- block add/edit invoice actions if invoice already grouped
- add tests for grouped invoice restrictions

## Testing
- `composer install` *(fails: command not found)*
- `vendor/bin/pest` *(fails: vendor missing)*

------
https://chatgpt.com/codex/tasks/task_e_6853029bd97483208d5eb6954bbb5f85