### PR TITLE
Allow adding items to grouped invoices

### DIFF
--- a/app/Livewire/Admin/Invoices/AddInvoiceItems.php
+++ b/app/Livewire/Admin/Invoices/AddInvoiceItems.php
@@ -25,10 +25,6 @@ class AddInvoiceItems extends Component
 
     public function mount(Invoice $invoice)
     {
-        if ($invoice->global_invoice_id) {
-            session()->flash('error', "La facture {$invoice->invoice_number} est déjà incluse dans une facture globale. Impossible de la modifier.");
-            redirect()->route('invoices.show', $invoice->id);
-        }
 
         $this->invoice = $invoice->load('items');
         $this->taxes = Tax::orderBy('label')->get();

--- a/tests/Feature/Admin/AddInvoiceItemsTest.php
+++ b/tests/Feature/Admin/AddInvoiceItemsTest.php
@@ -57,7 +57,7 @@ class AddInvoiceItemsTest extends TestCase
         ]);
     }
 
-    public function test_cannot_add_items_to_grouped_invoice(): void
+    public function test_items_can_be_added_to_grouped_invoice(): void
     {
         $user = User::factory()->create();
         $this->actingAs($user);
@@ -69,8 +69,35 @@ class AddInvoiceItemsTest extends TestCase
             'global_invoice_id' => $global->id,
         ]);
 
+        $tax = Tax::factory()->create();
+        $agency = AgencyFee::factory()->create();
+        $extra = ExtraFee::factory()->create();
+
         Livewire::test(AddInvoiceItems::class, ['invoice' => $invoice->id])
-            ->assertRedirect(route('invoices.show', $invoice->id))
-            ->assertSessionHas('error');
+            ->set('taxItems', [['tax_id' => $tax->id, 'amount_usd' => 10]])
+            ->set('agencyFeeItems', [['agency_fee_id' => $agency->id, 'amount_usd' => 20]])
+            ->set('extraFeeItems', [['extra_fee_id' => $extra->id, 'amount_usd' => 5]])
+            ->call('save');
+
+        $this->assertDatabaseHas('invoice_items', [
+            'invoice_id' => $invoice->id,
+            'tax_id' => $tax->id,
+            'category' => 'import_tax',
+            'amount_usd' => 10,
+        ]);
+
+        $this->assertDatabaseHas('invoice_items', [
+            'invoice_id' => $invoice->id,
+            'agency_fee_id' => $agency->id,
+            'category' => 'agency_fee',
+            'amount_usd' => 20,
+        ]);
+
+        $this->assertDatabaseHas('invoice_items', [
+            'invoice_id' => $invoice->id,
+            'extra_fee_id' => $extra->id,
+            'category' => 'extra_fee',
+            'amount_usd' => 5,
+        ]);
     }
 }


### PR DESCRIPTION
## Summary
- permit adding line items to grouped invoices by removing the check in the Livewire component
- update tests to verify grouped invoices accept additional items

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853e357c3608320b7bbc612b4a9f3ad