### PR TITLE
Add invoice sync and validation

### DIFF
--- a/app/Livewire/Admin/Invoices/OperationInvoice.php
+++ b/app/Livewire/Admin/Invoices/OperationInvoice.php
@@ -59,6 +59,21 @@ class OperationInvoice extends Component
         }
     }
 
+    public function validateInvoice(): void
+    {
+        if (!$this->invoice) {
+            session()->flash('error', 'Aucune facture chargée.');
+            return;
+        }
+
+        $this->invoice->total_usd = $this->invoice->items()->sum('amount_usd');
+        $this->invoice->status = 'approved';
+        $this->invoice->save();
+
+        session()->flash('success', 'Opération validée et total mis à jour.');
+        $this->loadInvoice();
+    }
+
     public function render()
     {
         return view('livewire.admin.invoices.operation-invoice');

--- a/app/Livewire/Admin/Invoices/SyncInvoice.php
+++ b/app/Livewire/Admin/Invoices/SyncInvoice.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Livewire\Admin\Invoices;
+
+use Livewire\Component;
+use App\Models\Invoice;
+
+class SyncInvoice extends Component
+{
+    public Invoice $invoice;
+    public float $itemsTotal = 0;
+    public float $difference = 0;
+
+    public function mount(Invoice $invoice): void
+    {
+        $this->invoice = $invoice->load('items');
+        $this->calculateTotals();
+    }
+
+    public function calculateTotals(): void
+    {
+        $this->itemsTotal = $this->invoice->items->sum('amount_usd');
+        $this->difference = round($this->itemsTotal - $this->invoice->total_usd, 2);
+    }
+
+    public function synchronize(): void
+    {
+        $this->calculateTotals();
+        $this->invoice->total_usd = $this->itemsTotal;
+        $this->invoice->save();
+        $this->difference = 0;
+        session()->flash('success', 'Facture synchronisée avec succès.');
+    }
+
+    public function render()
+    {
+        return view('livewire.admin.invoices.sync-invoice');
+    }
+}

--- a/resources/views/livewire/admin/invoices/operation-invoice.blade.php
+++ b/resources/views/livewire/admin/invoices/operation-invoice.blade.php
@@ -24,6 +24,10 @@
                     </div>
                 </div>
             @endforeach
+
+            <div class="flex justify-end pt-4">
+                <x-forms.button type="button" wire:click="validateInvoice">Valider l'opération</x-forms.button>
+            </div>
         </div>
     @endif
 </div>

--- a/resources/views/livewire/admin/invoices/sync-invoice.blade.php
+++ b/resources/views/livewire/admin/invoices/sync-invoice.blade.php
@@ -1,0 +1,21 @@
+<div class="max-w-xl mx-auto p-6 space-y-6">
+    <x-ui.flash-message />
+    <x-ui.error-message />
+
+    <div class="bg-white dark:bg-gray-800 border rounded-xl p-6 space-y-4">
+        <h2 class="text-lg font-semibold text-gray-800 dark:text-white">
+            Synchronisation Facture {{ $invoice->invoice_number }}
+        </h2>
+        <p>Total calculé depuis les lignes : <strong>{{ number_format($itemsTotal, 2) }} USD</strong></p>
+        <p>Total enregistré : <strong>{{ number_format($invoice->total_usd, 2) }} USD</strong></p>
+
+        @if($difference != 0)
+            <div class="text-red-600">
+                Différence détectée de {{ number_format($difference, 2) }} USD.
+            </div>
+            <x-forms.button type="button" wire:click="synchronize" class="mt-4">Synchroniser</x-forms.button>
+        @else
+            <div class="text-green-600">Aucune différence détectée.</div>
+        @endif
+    </div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -156,6 +156,7 @@ Route::get('/notifications/latest', [NotificationController::class, 'latest'])->
         Route::get('/index', InvoiceIndex::class)->name('index');
         Route::get('/{invoice}/edit', UpdateInvoice::class)->name('invoices.edit');
         Route::get('/{invoice}/items', \App\Livewire\Admin\Invoices\AddInvoiceItems::class)->name('items.add');
+        Route::get('/{invoice}/sync', \App\Livewire\Admin\Invoices\SyncInvoice::class)->name('sync');
         Route::get('/operations', \App\Livewire\Admin\Invoices\OperationInvoice::class)->name('operations');
         Route::get('/trash', InvoiceTrash::class)->name('trash');
 


### PR DESCRIPTION
## Summary
- allow validation of invoice operations to refresh total and approve
- add synchronization component to verify invoice total vs item sum
- expose sync functionality with a route

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854055d1b80832081fb21a2ab2b66e4