### PR TITLE
Add progress overlay for global invoices

### DIFF
--- a/resources/views/livewire/admin/invoices/global-invoice-show.blade.php
+++ b/resources/views/livewire/admin/invoices/global-invoice-show.blade.php
@@ -1,5 +1,13 @@
-<div>
-    <div class="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
+<div x-data="loadingProgress({{ $globalInvoice->invoices->count() }})" x-init="start()" class="relative">
+    <div x-show="loading" class="absolute inset-0 flex flex-col items-center justify-center bg-white z-50">
+        <p class="mb-2 text-gray-700">Chargement des dossiers groupés...</p>
+        <div class="w-64 bg-gray-200 rounded-full h-4 overflow-hidden">
+            <div class="bg-blue-500 h-4" :style="`width: ${(progress/total)*100}%`"></div>
+        </div>
+        <p class="mt-2 text-sm text-gray-600" x-text="`${progress}/${total}`"></p>
+    </div>
+
+    <div x-show="!loading" x-cloak class="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div class="bg-white shadow-xl rounded-lg overflow-hidden">
             <div class="px-6 py-4 bg-gray-50 border-b border-gray-200 flex justify-between items-center">
                 <h1 class="text-2xl font-semibold text-gray-700">
@@ -187,3 +195,23 @@
         </div>
     </div>
 </div>
+
+<script>
+    function loadingProgress(total) {
+        return {
+            progress: 0,
+            total: total,
+            loading: true,
+            start() {
+                const timer = setInterval(() => {
+                    if (this.progress < this.total) {
+                        this.progress++;
+                    } else {
+                        clearInterval(timer);
+                        this.loading = false;
+                    }
+                }, 300);
+            }
+        }
+    }
+</script>


### PR DESCRIPTION
## Summary
- show progress bar counting dossiers before displaying a global invoice

## Testing
- `phpunit` *(fails: command not found)*
- `npm test` *(no tests defined)*

------
https://chatgpt.com/codex/tasks/task_e_6854268b0e90832098bb19c432bac716