### PR TITLE
Synchronize global invoice with partial changes

### DIFF
--- a/app/Livewire/Admin/Invoices/GlobalInvoiceShow.php
+++ b/app/Livewire/Admin/Invoices/GlobalInvoiceShow.php
@@ -10,10 +10,23 @@ use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Maatwebsite\Excel\Facades\Excel;
 use App\Exports\GlobalInvoiceSummaryExport;
 use App\Services\Enterprise\EnterpriseService;
+use App\Services\Invoice\GlobalInvoiceService;
 
 class GlobalInvoiceShow extends Component
 {
     public GlobalInvoice $globalInvoice;
+
+    /**
+     * Vérifie si les factures partielles associées ont été modifiées.
+     * Si c'est le cas, synchronise la facture globale.
+     */
+    public function checkPartialsUpdates(GlobalInvoiceService $service): void
+    {
+        if ($service->syncGlobalInvoice($this->globalInvoice)) {
+            $this->globalInvoice->refresh()->load(['globalInvoiceItems', 'company', 'invoices']);
+            session()->flash('success', 'Des mises à jour des factures partielles ont été détectées. La facture globale a été synchronisée.');
+        }
+    }
 
     public function mount(GlobalInvoice $globalInvoice): void
     {

--- a/resources/views/livewire/admin/invoices/global-invoice-show.blade.php
+++ b/resources/views/livewire/admin/invoices/global-invoice-show.blade.php
@@ -1,4 +1,4 @@
-<div x-data="loadingProgress({{ $globalInvoice->invoices->count() }})" x-init="start()" class="relative">
+<div x-data="loadingProgress({{ $globalInvoice->invoices->count() }})" x-init="start()" wire:init="checkPartialsUpdates" class="relative">
     <div x-show="loading" class="absolute inset-0 flex flex-col items-center justify-center bg-white z-50">
         <p class="mb-2 text-gray-700">Chargement des dossiers groupés...</p>
         <div class="w-72 md:w-96 bg-gray-200 rounded-full h-4 overflow-hidden">


### PR DESCRIPTION
## Summary
- detect modifications on partial invoices when viewing a global invoice
- synchronize the global invoice items and amount when changes are found
- trigger check automatically on the global invoice page

## Testing
- `composer install` *(fails: command not found)*
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685428f3d5788320a6dd333e640cc8bb