### PR TITLE
Fix undefined variable in global invoice view

### DIFF
--- a/resources/views/livewire/admin/invoices/edit-global-invoice.blade.php
+++ b/resources/views/livewire/admin/invoices/edit-global-invoice.blade.php
@@ -30,7 +30,7 @@
     </div>
 
     <div class="mt-6 text-right">
-        <p class="font-semibold mb-2">Total: {{ number_format($totalAmount, 2) }} USD</p>
+        <p class="font-semibold mb-2">Total: {{ number_format($this->totalAmount, 2) }} USD</p>
         <button wire:click="save" class="px-6 py-2 bg-blue-600 text-white rounded">Enregistrer</button>
     </div>
 </div>


### PR DESCRIPTION
## Summary
- fix Livewire view referencing undefined `$totalAmount`

## Testing
- `composer install` *(fails: command not found)*
- `vendor/bin/pest` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68550acf37a08320bf3dea60ef64905a