### PR TITLE
Enable tax ID editing in partial invoice operations

### DIFF
--- a/app/Livewire/Admin/Invoices/OperationInvoice.php
+++ b/app/Livewire/Admin/Invoices/OperationInvoice.php
@@ -5,12 +5,14 @@ namespace App\Livewire\Admin\Invoices;
 use Livewire\Component;
 use App\Models\Invoice;
 use App\Models\InvoiceItem;
+use App\Models\Tax;
 
 class OperationInvoice extends Component
 {
     public string $invoiceNumber = '';
     public ?Invoice $invoice = null;
     public array $items = [];
+    public array $taxes = [];
 
     public function loadInvoice(): void
     {
@@ -21,6 +23,8 @@ class OperationInvoice extends Component
         $this->invoice = Invoice::where('invoice_number', $this->invoiceNumber)
             ->with('items')
             ->first();
+
+        $this->taxes = Tax::orderBy('label')->get();
 
         if (!$this->invoice) {
             $this->items = [];
@@ -33,6 +37,7 @@ class OperationInvoice extends Component
                 'id' => $item->id,
                 'label' => $item->label,
                 'amount_usd' => $item->amount_usd,
+                'tax_id' => $item->tax_id,
             ];
         })->toArray();
     }
@@ -42,6 +47,7 @@ class OperationInvoice extends Component
         $this->validate([
             'items.' . $index . '.label' => 'required|string',
             'items.' . $index . '.amount_usd' => 'required|numeric',
+            'items.' . $index . '.tax_id' => 'nullable|exists:taxes,id',
         ]);
 
         $data = $this->items[$index];
@@ -50,6 +56,7 @@ class OperationInvoice extends Component
             $item->update([
                 'label' => $data['label'],
                 'amount_usd' => $data['amount_usd'],
+                'tax_id' => $data['tax_id'] ?? null,
             ]);
 
             $this->invoice->total_usd = $this->invoice->items()->sum('amount_usd');

--- a/resources/views/livewire/admin/invoices/operation-invoice.blade.php
+++ b/resources/views/livewire/admin/invoices/operation-invoice.blade.php
@@ -13,13 +13,16 @@
 
             @foreach($items as $i => $item)
                 <div class="grid grid-cols-12 gap-2 items-end">
-                    <div class="col-span-6">
+                    <div class="col-span-5">
                         <x-forms.input label="Libellé" :model="'items.' . $i . '.label'" />
                     </div>
-                    <div class="col-span-4">
+                    <div class="col-span-3">
                         <x-forms.input label="Montant USD" type="number" step="0.01" :model="'items.' . $i . '.amount_usd'" />
                     </div>
-                    <div class="col-span-2 flex justify-end">
+                    <div class="col-span-3">
+                        <x-forms.select label="Taxe" :model="'items.' . $i . '.tax_id'" :options="$taxes" optionLabel="label" optionValue="id" />
+                    </div>
+                    <div class="col-span-1 flex justify-end">
                         <x-forms.button type="button" wire:click="updateItem({{ $i }})">Valider</x-forms.button>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- allow `OperationInvoice` to load available taxes
- include `tax_id` when mapping invoice items
- validate and save `tax_id` in item updates
- add a dropdown in the operation invoice view for tax selection

## Testing
- `composer install` *(fails: composer not found)*
- `phpunit` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_68550e99ca5c8320aa0b216a353116d0