### PR TITLE
Add global invoice regeneration

### DIFF
--- a/app/Livewire/Admin/Invoices/GlobalInvoiceShow.php
+++ b/app/Livewire/Admin/Invoices/GlobalInvoiceShow.php
@@ -62,6 +62,20 @@ class GlobalInvoiceShow extends Component
         return Excel::download(new GlobalInvoiceSummaryExport($this->globalInvoice), $filename);
     }
 
+    /**
+     * Régénère la facture globale en se basant sur les factures partielles actives.
+     * Le numéro de facture reste inchangé.
+     */
+    public function regenerate(GlobalInvoiceService $service): void
+    {
+        if ($service->syncGlobalInvoice($this->globalInvoice)) {
+            $this->globalInvoice->refresh()->load(['globalInvoiceItems', 'company', 'invoices']);
+            session()->flash('success', 'Facture globale régénérée avec succès.');
+        } else {
+            session()->flash('success', 'Aucune mise à jour nécessaire.');
+        }
+    }
+
     public function render()
     {
         return view('livewire.admin.invoices.global-invoice-show'); // Supposant une layout admin existante

--- a/resources/views/livewire/admin/invoices/global-invoice-show.blade.php
+++ b/resources/views/livewire/admin/invoices/global-invoice-show.blade.php
@@ -43,6 +43,12 @@
                         <span wire:loading wire:target="exportSummary">Export...</span>
                     </button>
 
+                    <button
+                        wire:click="regenerate"
+                        class="ml-2 px-4 py-2 bg-yellow-500 hover:bg-yellow-600 text-white font-semibold rounded-lg shadow-md focus:outline-none focus:ring-2 focus:ring-yellow-400 focus:ring-opacity-75 transition duration-150 ease-in-out">
+                        🔁 Régénérer
+                    </button>
+
                     {{-- Barre de progression lors de la génération du PDF --}}
                     <div wire:loading wire:target="downloadPdf" class="mt-2">
                         <div class="w-full bg-gray-200 rounded-full h-2.5 overflow-hidden">


### PR DESCRIPTION
## Summary
- add `regenerate` method to refresh global invoices from partials
- provide a button on the invoice show page to trigger regeneration

## Testing
- `./vendor/bin/pest` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_685512d506308320a42496d9b88f5f14