### PR TITLE
Fix global invoice editing and remove auto sync loader

### DIFF
--- a/app/Livewire/Admin/Invoices/EditGlobalInvoice.php
+++ b/app/Livewire/Admin/Invoices/EditGlobalInvoice.php
@@ -84,7 +84,7 @@ class EditGlobalInvoice extends Component
         });
 
         session()->flash('success', 'Facture globale mise à jour.');
-        redirect()->route('admin.global-invoices.show', $this->globalInvoice->id);
+        return redirect()->route('admin.global-invoices.show', $this->globalInvoice->id);
     }
 
     public function render()

--- a/resources/views/livewire/admin/invoices/global-invoice-show.blade.php
+++ b/resources/views/livewire/admin/invoices/global-invoice-show.blade.php
@@ -1,16 +1,5 @@
-<div x-data="loadingProgress({{ $globalInvoice->invoices->count() }})" x-init="start()" wire:init="checkPartialsUpdates" class="relative">
-    <div x-show="loading" class="absolute inset-0 flex flex-col items-center justify-center bg-white z-50">
-        <p class="mb-2 text-gray-700">Chargement des dossiers groupés...</p>
-        <div class="w-72 md:w-96 bg-gray-200 rounded-full h-4 overflow-hidden">
-            <div class="bg-gradient-to-r from-blue-500 to-green-500 h-4" :style="`width: ${(progress/total)*100}%`"></div>
-        </div>
-        <p class="mt-4 text-xl font-semibold text-gray-800 flex items-center gap-2">
-            <span class="text-2xl">🔄</span>
-            <span x-text="`${progress}/${total}`"></span>
-        </p>
-    </div>
-
-    <div x-show="!loading" x-cloak class="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
+<div class="relative">
+    <div class="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div class="bg-white shadow-xl rounded-lg overflow-hidden">
             <div class="px-6 py-4 bg-gray-50 border-b border-gray-200 flex justify-between items-center">
                 <h1 class="text-2xl font-semibold text-gray-700">
@@ -209,22 +198,3 @@
     </div>
 </div>
 
-<script>
-    function loadingProgress(total) {
-        return {
-            progress: 0,
-            total: total,
-            loading: true,
-            start() {
-                const timer = setInterval(() => {
-                    if (this.progress < this.total) {
-                        this.progress++;
-                    } else {
-                        clearInterval(timer);
-                        this.loading = false;
-                    }
-                }, 300);
-            }
-        }
-    }
-</script>


### PR DESCRIPTION
## Summary
- enable redirect after editing a global invoice
- remove automatic synchronization and loading counter from global invoice show page

## Testing
- `php artisan test` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855160773a08320afb910b316f2f668