### PR TITLE
Fix redirect in EditGlobalInvoice

### DIFF
--- a/app/Livewire/Admin/Invoices/EditGlobalInvoice.php
+++ b/app/Livewire/Admin/Invoices/EditGlobalInvoice.php
@@ -84,7 +84,7 @@ class EditGlobalInvoice extends Component
         });
 
         session()->flash('success', 'Facture globale mise à jour.');
-        return redirect()->route('admin.global-invoices.show', $this->globalInvoice->id);
+        redirect()->route('admin.global-invoices.show', $this->globalInvoice->id);
     }
 
     public function render()


### PR DESCRIPTION
## Summary
- fix void function not returning redirect by removing `return`

## Testing
- `composer test` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685516eca4748320b7eb8ed249c0774e