### PR TITLE
Add product editing to global invoice

### DIFF
--- a/app/Livewire/Admin/Invoices/EditGlobalInvoice.php
+++ b/app/Livewire/Admin/Invoices/EditGlobalInvoice.php
@@ -11,10 +11,12 @@ class EditGlobalInvoice extends Component
 {
     public GlobalInvoice $globalInvoice;
     public array $items = [];
+    public string $product = '';
 
     public function mount(GlobalInvoice $globalInvoice): void
     {
         $this->globalInvoice = $globalInvoice;
+        $this->product = $globalInvoice->product ?? '';
         $this->items = $globalInvoice->globalInvoiceItems
             ->map(fn($item) => [
                 'id' => $item->id,
@@ -91,6 +93,10 @@ class EditGlobalInvoice extends Component
         foreach ($this->items as $index => $item) {
             $this->updateItem($index);
         }
+
+        $this->globalInvoice->update([
+            'product' => $this->product,
+        ]);
 
         session()->flash('success', 'Toutes les lignes ont été mises à jour avec ajustement du total.');
         redirect()->route('admin.global-invoices.show', $this->globalInvoice->id);

--- a/resources/views/livewire/admin/invoices/edit-global-invoice.blade.php
+++ b/resources/views/livewire/admin/invoices/edit-global-invoice.blade.php
@@ -6,6 +6,11 @@
         Éditer Facture Globale {{ $globalInvoice->global_invoice_number }}
     </h1>
 
+    <div class="mb-4 max-w-sm">
+        <label class="block mb-1 text-sm font-medium">Produit</label>
+        <input type="text" wire:model.defer="product" class="w-full border rounded p-1" />
+    </div>
+
     <div class="space-y-4">
         @foreach ($items as $index => $item)
             <div class="border p-4 rounded-lg shadow-sm">


### PR DESCRIPTION
## Summary
- allow editing the product field for a global invoice
- display product input on global invoice edit screen

## Testing
- `npm test` *(fails: Missing script)*
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68555716716083208f05ae0bb99c7ffc