### PR TITLE
Add quantity field to invoice items

### DIFF
--- a/app/Livewire/Admin/Invoices/GenerateInvoice.php
+++ b/app/Livewire/Admin/Invoices/GenerateInvoice.php
@@ -127,6 +127,7 @@ class GenerateInvoice extends Component
         $this->items[] = [
             'label' => '',
             'category' => $category,
+            'quantity' => 1,
             'currency_id' => $this->currency_id ?? 1,
             'exchange_rate' => $this->exchange_rate,
             'amount_local' => 0,
@@ -175,6 +176,7 @@ class GenerateInvoice extends Component
                 'currency_id' => 'required|integer|exists:currencies,id',
                 'exchange_rate' => 'required|numeric|min:0',
                 'items' => 'present|array|min:1',
+                'items.*.quantity' => 'required|integer|min:1',
                 'items.*.amount_local' => 'required|numeric|min:0',
                 'items.*.currency_id' => 'required|integer|exists:currencies,id',
                 'folder_id' => [
@@ -284,6 +286,7 @@ class GenerateInvoice extends Component
                     $invoice->items()->create([
                         'label' => $itemData['label'],
                         'category' => $itemData['category'],
+                        'quantity' => $itemData['quantity'] ?? 1,
                         'amount_usd' => $itemData['amount_usd'],
                         'amount_cdf' => $itemData['amount_cdf'],
                         'currency_id' => $itemData['currency_id'],

--- a/app/Models/InvoiceItem.php
+++ b/app/Models/InvoiceItem.php
@@ -14,6 +14,7 @@ class InvoiceItem extends Model
         'invoice_id',
         'label',
         'category',
+        'quantity',
         'amount_usd',
         'currency_id',
         'exchange_rate',
@@ -21,6 +22,10 @@ class InvoiceItem extends Model
         'tax_id',
         'agency_fee_id',
         'extra_fee_id',
+    ];
+
+    protected $casts = [
+        'quantity' => 'integer',
     ];
 
     // 🔁 Relations

--- a/app/Services/Invoice/GlobalInvoiceService.php
+++ b/app/Services/Invoice/GlobalInvoiceService.php
@@ -86,9 +86,9 @@ class GlobalInvoiceService
                         ];
                     }
 
-                    $aggregated[$key]['quantity'] += 1;
+                    $aggregated[$key]['quantity'] += $item->quantity ?? 1;
                     $aggregated[$key]['total_price'] += $item->amount_usd;
-                    $aggregated[$key]['unit_price'] = $item->amount_usd; // in case amounts vary
+                    $aggregated[$key]['unit_price'] = $item->quantity ? $item->amount_usd / $item->quantity : $item->amount_usd; // in case amounts vary
                     $aggregated[$key]['original_item_ids'][] = $item->id;
                 }
             }
@@ -163,9 +163,9 @@ class GlobalInvoiceService
                     ];
                 }
 
-                $aggregated[$key]['quantity'] += 1;
+                $aggregated[$key]['quantity'] += $item->quantity ?? 1;
                 $aggregated[$key]['total_price'] += $item->amount_usd;
-                $aggregated[$key]['unit_price'] = $item->amount_usd;
+                $aggregated[$key]['unit_price'] = $item->quantity ? $item->amount_usd / $item->quantity : $item->amount_usd;
                 $aggregated[$key]['original_item_ids'][] = $item->id;
             }
         }

--- a/database/migrations/2025_07_04_070853_add_quantity_to_invoice_items_table.php
+++ b/database/migrations/2025_07_04_070853_add_quantity_to_invoice_items_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('invoice_items', function (Blueprint $table) {
+            if (!Schema::hasColumn('invoice_items', 'quantity')) {
+                $table->unsignedInteger('quantity')->default(1)->after('category');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('invoice_items', function (Blueprint $table) {
+            if (Schema::hasColumn('invoice_items', 'quantity')) {
+                $table->dropColumn('quantity');
+            }
+        });
+    }
+};

--- a/resources/views/livewire/admin/invoices/generate-invoice.blade.php
+++ b/resources/views/livewire/admin/invoices/generate-invoice.blade.php
@@ -111,7 +111,7 @@
 
                 @foreach ($items as $i => $item)
                     @if ($item['category'] === $category)
-                        <div class="grid grid-cols-6 gap-4 items-end mb-3">
+                        <div class="grid grid-cols-7 gap-4 items-end mb-3">
                             @if ($category === 'import_tax')
                                 <x-forms.select label="Taxe" :model="'items.' . $i . '.tax_id'" :options="$taxes" optionLabel="label"
                                     optionValue="id" />
@@ -125,6 +125,8 @@
 
                             <x-forms.select label="Devise" :model="'items.' . $i . '.currency_id'" :options="$currencies" optionLabel="code"
                                 optionValue="id" />
+
+                            <x-forms.input label="Quantité" :model="'items.' . $i . '.quantity'" type="number" step="1" />
 
                             <x-forms.input label="Montant (devise locale)" :model="'items.' . $i . '.amount_local'" type="number"
                                 step="0.01" />


### PR DESCRIPTION
## Summary
- allow specifying quantity when generating invoices
- store quantity in invoice items
- handle quantity when aggregating into global invoices
- display quantity input on invoice creation form

## Testing
- `./vendor/bin/pest` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68677ce9b3008320848d8e60982cd937