### PR TITLE
Add advanced dossier filters

### DIFF
--- a/app/Livewire/Admin/Folder/FolderList.php
+++ b/app/Livewire/Admin/Folder/FolderList.php
@@ -4,6 +4,8 @@ namespace App\Livewire\Admin\Folder;
 
 use App\Exports\FolderExport;
 use App\Models\Folder;
+use App\Enums\DossierType;
+use App\Models\Company;
 use App\Models\Transporter;
 use Livewire\Component;
 use Livewire\WithPagination;
@@ -23,7 +25,15 @@ class FolderList extends Component
 
     public $filterDateTo = null;
 
+    public $filterCompany = null;
+
+    public $filterType = null;
+
     public $transporters;
+
+    public $companies;
+
+    public $dossierTypeOptions;
 
     public $allColumns = [
         'folder_number' => 'Folder',
@@ -81,6 +91,8 @@ class FolderList extends Component
     public function mount()
     {
         $this->transporters = Transporter::all();
+        $this->companies = Company::notDeleted()->orderBy('name')->get(['id','name']);
+        $this->dossierTypeOptions = DossierType::options();
         // Initialize visibleColumns with a default set if not already set by Livewire's mechanisms
         if (empty($this->visibleColumns)) {
             $this->visibleColumns = [
@@ -131,6 +143,8 @@ class FolderList extends Component
                     ->orWhere('client', 'like', '%' . $this->search . '%');
             })
             ->when($this->filterTransporter, fn($q) => $q->where('transporter_id', $this->filterTransporter))
+            ->when($this->filterCompany, fn($q) => $q->where('company_id', $this->filterCompany))
+            ->when($this->filterType, fn($q) => $q->where('dossier_type', $this->filterType))
             ->when($this->filterDateFrom, fn($q) => $q->whereDate('arrival_border_date', '>=', $this->filterDateFrom))
             ->when($this->filterDateTo, fn($q) => $q->whereDate('arrival_border_date', '<=', $this->filterDateTo))
             ->orderBy('created_at')
@@ -139,6 +153,8 @@ class FolderList extends Component
         return view('livewire.admin.folder.folder-list', [
             'folders' => $folders,
             'totalFolders' => $folders->total(),
+            'companies' => $this->companies,
+            'dossierTypeOptions' => $this->dossierTypeOptions,
         ]);
     }
 }

--- a/resources/views/livewire/admin/folder/folder-list.blade.php
+++ b/resources/views/livewire/admin/folder/folder-list.blade.php
@@ -33,6 +33,15 @@
             </div>
         @endif
 
+        <div class="flex flex-wrap gap-2 mb-4">
+            <x-forms.input model="search" placeholder="🔍 Rechercher..." class="w-full sm:w-1/4" />
+            <x-forms.select model="filterCompany" :options="$companies" option-label="name" option-value="id" placeholder="-- Compagnie --" class="w-full sm:w-1/5" />
+            <x-forms.select model="filterType" :options="$dossierTypeOptions" option-label="label" option-value="value" placeholder="-- Type --" class="w-full sm:w-1/5" />
+            <x-forms.select model="filterTransporter" :options="$transporters" option-label="name" option-value="id" placeholder="-- Transporteur --" class="w-full sm:w-1/5" />
+            <x-forms.input model="filterDateFrom" type="date" placeholder="De" class="w-full sm:w-1/6" />
+            <x-forms.input model="filterDateTo" type="date" placeholder="À" class="w-full sm:w-1/6" />
+        </div>
+
         <div class="overflow-x-auto border border-gray-200 dark:border-gray-800 rounded-xl shadow-sm">
             <table class="min-w-full divide-y divide-gray-200 dark:divide-gray-700 text-sm">
                 <thead class="bg-gray-50 dark:bg-gray-800 text-gray-700 dark:text-white sticky top-0 z-10">


### PR DESCRIPTION
## Summary
- enable filtering by company and dossier type
- add search and date filters to the dossier list UI

## Testing
- `./vendor/bin/phpunit` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_68677f58600c8320bea4b209a38ab89c