### PR TITLE
Add invoice status filter to folder list

### DIFF
--- a/app/Livewire/Admin/Folder/FolderList.php
+++ b/app/Livewire/Admin/Folder/FolderList.php
@@ -29,6 +29,10 @@ class FolderList extends Component
 
     public $filterType = null;
 
+    public $filterInvoiceStatus = null;
+
+    public $invoiceStatusOptions = [];
+
     public $transporters;
 
     public $companies;
@@ -95,6 +99,10 @@ class FolderList extends Component
         $this->transporters = Transporter::all();
         $this->companies = Company::notDeleted()->orderBy('name')->get(['id','name']);
         $this->dossierTypeOptions = DossierType::options();
+        $this->invoiceStatusOptions = [
+            ['id' => 'invoiced', 'name' => 'Déjà facturé'],
+            ['id' => 'not_invoiced', 'name' => 'Non facturé'],
+        ];
         // Initialize visibleColumns with a default set if not already set by Livewire's mechanisms
         if (empty($this->visibleColumns)) {
             $this->visibleColumns = [
@@ -149,6 +157,8 @@ class FolderList extends Component
             ->when($this->filterType, fn($q) => $q->where('dossier_type', $this->filterType))
             ->when($this->filterDateFrom, fn($q) => $q->whereDate('arrival_border_date', '>=', $this->filterDateFrom))
             ->when($this->filterDateTo, fn($q) => $q->whereDate('arrival_border_date', '<=', $this->filterDateTo))
+            ->when($this->filterInvoiceStatus === 'invoiced', fn($q) => $q->whereHas('invoice'))
+            ->when($this->filterInvoiceStatus === 'not_invoiced', fn($q) => $q->whereDoesntHave('invoice'))
             ->orderByDesc('created_at')
             ->paginate($this->perPage);
 
@@ -157,6 +167,7 @@ class FolderList extends Component
             'totalFolders' => $folders->total(),
             'companies' => $this->companies,
             'dossierTypeOptions' => $this->dossierTypeOptions,
+            'invoiceStatusOptions' => $this->invoiceStatusOptions,
         ]);
     }
 }

--- a/resources/views/livewire/admin/folder/folder-list.blade.php
+++ b/resources/views/livewire/admin/folder/folder-list.blade.php
@@ -35,11 +35,12 @@
 
         <div class="mb-4 p-4 border border-gray-200 dark:border-gray-700 rounded-lg bg-gray-50 dark:bg-gray-900">
             <h4 class="text-lg font-semibold mb-3 text-gray-800 dark:text-gray-200">Filtres</h4>
-            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6 gap-2">
+            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-7 gap-2">
                 <x-forms.input model="search" placeholder="🔍 Rechercher..." class="w-full" />
                 <x-forms.select model="filterCompany" :options="$companies" option-label="name" option-value="id" placeholder="-- Compagnie --" class="w-full" />
                 <x-forms.select model="filterType" :options="$dossierTypeOptions" option-label="label" option-value="value" placeholder="-- Type --" class="w-full" />
                 <x-forms.select model="filterTransporter" :options="$transporters" option-label="name" option-value="id" placeholder="-- Transporteur --" class="w-full" />
+                <x-forms.select model="filterInvoiceStatus" :options="$invoiceStatusOptions" option-label="name" option-value="id" placeholder="-- Facturation --" class="w-full" />
                 <x-forms.input model="filterDateFrom" type="date" placeholder="De" class="w-full" />
                 <x-forms.input model="filterDateTo" type="date" placeholder="À" class="w-full" />
             </div>


### PR DESCRIPTION
## Summary
- add `filterInvoiceStatus` to FolderList component
- populate new filter options in `mount`
- filter results based on invoice presence
- pass and display invoice filter in folder list view
- expand filter grid to maintain responsive layout

## Testing
- `./vendor/bin/pest` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6867a03387948320afb53d98ae874004