### PR TITLE
Fix taxes property type in OperationInvoice

### DIFF
--- a/app/Livewire/Admin/Invoices/OperationInvoice.php
+++ b/app/Livewire/Admin/Invoices/OperationInvoice.php
@@ -12,7 +12,14 @@ class OperationInvoice extends Component
     public string $invoiceNumber = '';
     public ?Invoice $invoice = null;
     public array $items = [];
-    public array $taxes = [];
+    /**
+     * List of available taxes for the select options.
+     *
+     * Livewire components often keep Eloquent collections in public
+     * properties, so this property is intentionally untyped to avoid
+     * type errors when assigning a collection.
+     */
+    public $taxes = [];
 
     public function loadInvoice(): void
     {


### PR DESCRIPTION
## Summary
- fix type mismatch on OperationInvoice taxes property

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867c7d43500832098dbef6ef08bdabe