### PR TITLE
Prevent editing invoices already grouped

### DIFF
--- a/app/Livewire/Admin/Invoices/OperationInvoice.php
+++ b/app/Livewire/Admin/Invoices/OperationInvoice.php
@@ -39,6 +39,13 @@ class OperationInvoice extends Component
             return;
         }
 
+        if ($this->invoice->global_invoice_id) {
+            session()->flash('error', "La facture {$this->invoice->invoice_number} est déjà incluse dans une facture globale. Impossible de la modifier.");
+            $this->invoice = null;
+            $this->items = [];
+            return;
+        }
+
         $this->items = $this->invoice->items->map(function ($item) {
             return [
                 'id' => $item->id,
@@ -58,6 +65,11 @@ class OperationInvoice extends Component
             'items.' . $index . '.amount_usd' => 'required|numeric',
             'items.' . $index . '.tax_id' => 'nullable|exists:taxes,id',
         ]);
+
+        if ($this->invoice?->global_invoice_id) {
+            session()->flash('error', 'Impossible de modifier une facture déjà incluse dans une facture globale.');
+            return;
+        }
 
         $data = $this->items[$index];
         $item = InvoiceItem::find($data['id']);
@@ -80,6 +92,11 @@ class OperationInvoice extends Component
     {
         if (!$this->invoice) {
             session()->flash('error', 'Aucune facture chargée.');
+            return;
+        }
+
+        if ($this->invoice->global_invoice_id) {
+            session()->flash('error', 'Cette facture est déjà incluse dans une facture globale.');
             return;
         }
 


### PR DESCRIPTION
## Summary
- restrict invoice operations when invoice is already grouped in a global invoice

## Testing
- `composer --version` *(fails: command not found)*
- `php --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867ca9f973083209cfa34d78594b57d