### PR TITLE
Add folder balance view

### DIFF
--- a/app/Livewire/Admin/Billing/BillingIndex.php
+++ b/app/Livewire/Admin/Billing/BillingIndex.php
@@ -3,11 +3,18 @@
 namespace App\Livewire\Admin\Billing;
 
 use Livewire\Component;
+use App\Models\Folder;
 
 class BillingIndex extends Component
 {
     public function render()
     {
-        return view('livewire.admin.billing.billing-index');
+        $folders = Folder::with('transactions')
+            ->has('transactions')
+            ->get();
+
+        return view('livewire.admin.billing.billing-index', [
+            'folders' => $folders,
+        ]);
     }
 }

--- a/app/Models/Folder.php
+++ b/app/Models/Folder.php
@@ -171,6 +171,18 @@ class Folder extends Model
         return $this->hasMany(FolderTransaction::class);
     }
 
+    /**
+     * Compute the balance of all transactions for the folder.
+     */
+    public function balance(): Attribute
+    {
+        return Attribute::get(function (): float {
+            $income = $this->transactions()->where('type', 'income')->sum('amount');
+            $expense = $this->transactions()->where('type', 'expense')->sum('amount');
+            return $income - $expense;
+        });
+    }
+
     public $sortable = [
         'id', 'folder_number', 'truck_number', 'trailer_number',
         'invoice_number', 'goods_type', 'agency', 'pre_alert_place',

--- a/resources/views/livewire/admin/billing/billing-index.blade.php
+++ b/resources/views/livewire/admin/billing/billing-index.blade.php
@@ -1,3 +1,28 @@
-<div>
-    {{-- A good traveler has no fixed plans and is not intent upon arriving. --}}
+<div class="bg-white dark:bg-gray-900 p-6 rounded-xl shadow">
+    <h2 class="text-lg font-semibold mb-4">Dossiers en cours</h2>
+
+    <table class="min-w-full divide-y divide-gray-200 text-sm">
+        <thead class="bg-gray-50 dark:bg-gray-800">
+            <tr>
+                <th class="px-3 py-2 text-left">Dossier</th>
+                <th class="px-3 py-2 text-right">Solde</th>
+                <th class="px-3 py-2"></th>
+            </tr>
+        </thead>
+        <tbody class="bg-white dark:bg-gray-900 divide-y divide-gray-200">
+            @forelse($folders as $folder)
+                <tr>
+                    <td class="px-3 py-2">{{ $folder->folder_number }}</td>
+                    <td class="px-3 py-2 text-right">{{ number_format($folder->balance, 2, ',', ' ') }}</td>
+                    <td class="px-3 py-2 text-right">
+                        <a href="{{ route('folder.transactions', $folder->id) }}" class="text-blue-600 hover:underline">Ouvrir</a>
+                    </td>
+                </tr>
+            @empty
+                <tr>
+                    <td colspan="3" class="px-3 py-4 text-center text-gray-500">Aucun dossier.</td>
+                </tr>
+            @endforelse
+        </tbody>
+    </table>
 </div>

--- a/resources/views/livewire/admin/folder/folder-transaction-index.blade.php
+++ b/resources/views/livewire/admin/folder/folder-transaction-index.blade.php
@@ -15,7 +15,7 @@
             @foreach($transactions as $transaction)
                 <tr>
                     <td class="px-3 py-2">
-                        <a href="{{ route('folder.show', $transaction->folder_id) }}" class="text-indigo-600 hover:underline">
+                        <a href="{{ route('folder.transactions', $transaction->folder_id) }}" class="text-indigo-600 hover:underline">
                             {{ $transaction->folder->folder_number ?? '#' . $transaction->folder_id }}
                         </a>
                     </td>


### PR DESCRIPTION
## Summary
- compute folder balance from transactions
- show dossiers in progress in compta list with link to transactions
- update transaction listing to link directly to folder transactions

## Testing
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868cb3508548320b195582db48578b1