### PR TITLE
Add currency to folder transactions

### DIFF
--- a/app/Livewire/Admin/Folder/FolderTransactions.php
+++ b/app/Livewire/Admin/Folder/FolderTransactions.php
@@ -5,18 +5,22 @@ namespace App\Livewire\Admin\Folder;
 use Livewire\Component;
 use App\Models\Folder;
 use App\Models\FolderTransaction;
+use App\Models\Currency;
 
 class FolderTransactions extends Component
 {
     public Folder $folder;
     public $type = 'income';
     public $amount;
+    public $currency_id;
     public $label;
     public $transaction_date;
+    public $currencies = [];
 
     protected $rules = [
         'type' => 'required|in:income,expense',
         'amount' => 'required|numeric|min:0',
+        'currency_id' => 'required|exists:currencies,id',
         'label' => 'required|string|max:255',
         'transaction_date' => 'nullable|date',
     ];
@@ -24,6 +28,8 @@ class FolderTransactions extends Component
     public function mount(Folder $folder)
     {
         $this->folder = $folder;
+        $this->currencies = Currency::all();
+        $this->currency_id = $folder->currency_id;
     }
 
     public function saveTransaction()
@@ -33,12 +39,14 @@ class FolderTransactions extends Component
         $this->folder->transactions()->create([
             'type' => $this->type,
             'amount' => $this->amount,
+            'currency_id' => $this->currency_id,
             'label' => $this->label,
             'transaction_date' => $this->transaction_date,
         ]);
 
-        $this->reset('type', 'amount', 'label', 'transaction_date');
+        $this->reset('type', 'amount', 'currency_id', 'label', 'transaction_date');
         $this->type = 'income';
+        $this->currency_id = $this->folder->currency_id;
     }
 
     public function deleteTransaction($id)
@@ -62,6 +70,7 @@ class FolderTransactions extends Component
         return view('livewire.admin.folder.folder-transactions', [
             'transactions' => $transactions,
             'balance' => $this->balance,
+            'folder' => $this->folder,
         ]);
     }
 }

--- a/app/Models/FolderTransaction.php
+++ b/app/Models/FolderTransaction.php
@@ -13,6 +13,7 @@ class FolderTransaction extends Model
         'folder_id',
         'type',
         'amount',
+        'currency_id',
         'label',
         'transaction_date',
     ];
@@ -20,5 +21,10 @@ class FolderTransaction extends Model
     public function folder()
     {
         return $this->belongsTo(Folder::class);
+    }
+
+    public function currency()
+    {
+        return $this->belongsTo(Currency::class);
     }
 }

--- a/database/factories/FolderTransactionFactory.php
+++ b/database/factories/FolderTransactionFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\FolderTransaction;
+use App\Models\Folder;
+use App\Models\Currency;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class FolderTransactionFactory extends Factory
+{
+    protected $model = FolderTransaction::class;
+
+    public function definition()
+    {
+        return [
+            'folder_id' => Folder::factory(),
+            'type' => $this->faker->randomElement(['income', 'expense']),
+            'amount' => $this->faker->randomFloat(2, 10, 1000),
+            'currency_id' => Currency::factory(),
+            'label' => $this->faker->sentence(3),
+            'transaction_date' => $this->faker->date(),
+        ];
+    }
+}

--- a/database/migrations/2026_02_01_000000_add_currency_to_folder_transactions_table.php
+++ b/database/migrations/2026_02_01_000000_add_currency_to_folder_transactions_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('folder_transactions', function (Blueprint $table) {
+            $table->foreignId('currency_id')->nullable()->after('amount')
+                ->constrained('currencies')->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('folder_transactions', function (Blueprint $table) {
+            $table->dropForeign(['currency_id']);
+            $table->dropColumn('currency_id');
+        });
+    }
+};

--- a/resources/views/livewire/admin/folder/folder-transaction-index.blade.php
+++ b/resources/views/livewire/admin/folder/folder-transaction-index.blade.php
@@ -8,6 +8,7 @@
                 <th class="px-3 py-2 text-left">Date</th>
                 <th class="px-3 py-2 text-left">Libellé</th>
                 <th class="px-3 py-2 text-right">Montant</th>
+                <th class="px-3 py-2 text-left">Devise</th>
                 <th class="px-3 py-2 text-left">Type</th>
             </tr>
         </thead>
@@ -22,6 +23,7 @@
                     <td class="px-3 py-2">{{ optional($transaction->transaction_date)->format('d/m/Y') }}</td>
                     <td class="px-3 py-2">{{ $transaction->label }}</td>
                     <td class="px-3 py-2 text-right">{{ number_format($transaction->amount, 2, ',', ' ') }}</td>
+                    <td class="px-3 py-2">{{ $transaction->currency->code ?? '' }}</td>
                     <td class="px-3 py-2">{{ $transaction->type === 'income' ? 'Perçu' : 'Dépense' }}</td>
                 </tr>
             @endforeach

--- a/resources/views/livewire/admin/folder/folder-transactions.blade.php
+++ b/resources/views/livewire/admin/folder/folder-transactions.blade.php
@@ -7,6 +7,11 @@
                 <option value="income">Montant perçu</option>
                 <option value="expense">Dépense</option>
             </select>
+            <select wire:model.defer="currency_id" class="border rounded p-2">
+                @foreach($currencies as $c)
+                    <option value="{{ $c->id }}">{{ $c->code }}</option>
+                @endforeach
+            </select>
             <input type="text" wire:model.defer="label" placeholder="Libellé" class="border rounded p-2 flex-1">
             <input type="number" step="0.01" wire:model.defer="amount" placeholder="Montant" class="border rounded p-2 w-32">
             <input type="date" wire:model.defer="transaction_date" class="border rounded p-2">
@@ -21,6 +26,7 @@
                 <th class="px-3 py-2 text-left">Date</th>
                 <th class="px-3 py-2 text-left">Libellé</th>
                 <th class="px-3 py-2 text-right">Montant</th>
+                <th class="px-3 py-2 text-left">Devise</th>
                 <th class="px-3 py-2 text-left">Type</th>
                 <th class="px-3 py-2"></th>
             </tr>
@@ -31,6 +37,7 @@
                     <td class="px-3 py-2">{{ optional($transaction->transaction_date)->format('d/m/Y') }}</td>
                     <td class="px-3 py-2">{{ $transaction->label }}</td>
                     <td class="px-3 py-2 text-right">{{ number_format($transaction->amount, 2, ',', ' ') }}</td>
+                    <td class="px-3 py-2">{{ $transaction->currency->code ?? '' }}</td>
                     <td class="px-3 py-2">{{ $transaction->type === 'income' ? 'Perçu' : 'Dépense' }}</td>
                     <td class="px-3 py-2 text-right">
                         <button wire:click="deleteTransaction({{ $transaction->id }})" class="text-red-500">Supprimer</button>
@@ -46,7 +53,8 @@
             <tr class="font-semibold">
                 <td colspan="2" class="px-3 py-2 text-right">Solde</td>
                 <td class="px-3 py-2 text-right">{{ number_format($balance, 2, ',', ' ') }}</td>
-                <td colspan="2"></td>
+                <td>{{ $folder->currency->code ?? '' }}</td>
+                <td></td>
             </tr>
         </tfoot>
     </table>

--- a/tests/Feature/Livewire/Admin/Folder/FolderTransactionCurrencyTest.php
+++ b/tests/Feature/Livewire/Admin/Folder/FolderTransactionCurrencyTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Feature\Livewire\Admin\Folder;
+
+use App\Livewire\Admin\Folder\FolderTransactions;
+use App\Models\User;
+use App\Models\Folder;
+use App\Models\Currency;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class FolderTransactionCurrencyTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_transaction_can_be_created_with_currency(): void
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $currency = Currency::factory()->create(['code' => 'USD']);
+        $folder = Folder::factory()->create(['currency_id' => $currency->id]);
+
+        Livewire::test(FolderTransactions::class, ['folder' => $folder])
+            ->set('type', 'income')
+            ->set('label', 'Paiement')
+            ->set('amount', 100)
+            ->set('currency_id', $currency->id)
+            ->call('saveTransaction');
+
+        $this->assertDatabaseHas('folder_transactions', [
+            'folder_id' => $folder->id,
+            'type' => 'income',
+            'label' => 'Paiement',
+            'amount' => 100,
+            'currency_id' => $currency->id,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- support currencies for folder transactions
- show currency columns in transaction views
- provide factory and tests
- migration for folder transaction currency

## Testing
- `vendor/bin/phpunit --filter FolderTransactionCurrencyTest --colors=never` *(fails: phpunit not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868cf2a60c08320b045469549dd6b32