### PR TITLE
Show all folders on billing list

### DIFF
--- a/app/Livewire/Admin/Billing/BillingIndex.php
+++ b/app/Livewire/Admin/Billing/BillingIndex.php
@@ -9,9 +9,7 @@ class BillingIndex extends Component
 {
     public function render()
     {
-        $folders = Folder::with('transactions')
-            ->has('transactions')
-            ->get();
+        $folders = Folder::with('transactions')->get();
 
         return view('livewire.admin.billing.billing-index', [
             'folders' => $folders,

--- a/resources/views/livewire/admin/billing/billing-index.blade.php
+++ b/resources/views/livewire/admin/billing/billing-index.blade.php
@@ -15,7 +15,7 @@
                     <td class="px-3 py-2">{{ $folder->folder_number }}</td>
                     <td class="px-3 py-2 text-right">{{ number_format($folder->balance, 2, ',', ' ') }}</td>
                     <td class="px-3 py-2 text-right">
-                        <a href="{{ route('folder.transactions', $folder->id) }}" class="text-blue-600 hover:underline">Ouvrir</a>
+                        <a href="{{ route('folder.transactions', $folder->id) }}" class="text-blue-600 hover:underline">Détails</a>
                     </td>
                 </tr>
             @empty


### PR DESCRIPTION
## Summary
- list all folders on billing list page
- rename link to **Détails** to open folder transactions

## Testing
- `./vendor/bin/pest` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6868d1ee39b88320bcce044220fb786d