### PR TITLE
Implement cash register management for folder transactions

### DIFF
--- a/app/Livewire/Admin/CashRegister/CashRegisterIndex.php
+++ b/app/Livewire/Admin/CashRegister/CashRegisterIndex.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Livewire\Admin\CashRegister;
+
+use Livewire\Component;
+use App\Models\CashRegister;
+
+class CashRegisterIndex extends Component
+{
+    public $name;
+    public $balance = 0;
+
+    protected $rules = [
+        'name' => 'required|string|max:255',
+        'balance' => 'numeric',
+    ];
+
+    public function create()
+    {
+        $this->validate();
+
+        CashRegister::create([
+            'name' => $this->name,
+            'balance' => $this->balance,
+        ]);
+
+        $this->reset(['name', 'balance']);
+        session()->flash('success', 'Caisse créée avec succès.');
+    }
+
+    public function render()
+    {
+        return view('livewire.admin.cash-register.cash-register-index', [
+            'cashRegisters' => CashRegister::all(),
+        ]);
+    }
+}

--- a/app/Livewire/Admin/Folder/FolderTransactions.php
+++ b/app/Livewire/Admin/Folder/FolderTransactions.php
@@ -6,6 +6,8 @@ use Livewire\Component;
 use App\Models\Folder;
 use App\Models\FolderTransaction;
 use App\Models\Currency;
+use App\Models\CashRegister;
+use Illuminate\Support\Facades\Auth;
 
 class FolderTransactions extends Component
 {
@@ -13,14 +15,17 @@ class FolderTransactions extends Component
     public $type = 'income';
     public $amount;
     public $currency_id;
+    public $cash_register_id;
     public $label;
     public $transaction_date;
     public $currencies = [];
+    public $cashRegisters = [];
 
     protected $rules = [
         'type' => 'required|in:income,expense',
         'amount' => 'required|numeric|min:0',
         'currency_id' => 'required|exists:currencies,id',
+        'cash_register_id' => 'required|exists:cash_registers,id',
         'label' => 'required|string|max:255',
         'transaction_date' => 'nullable|date',
     ];
@@ -29,39 +34,68 @@ class FolderTransactions extends Component
     {
         $this->folder = $folder;
         $this->currencies = Currency::all();
+        $this->cashRegisters = CashRegister::all();
         $this->currency_id = $folder->currency_id;
+        $this->cash_register_id = $this->cashRegisters->first()->id ?? null;
     }
 
     public function saveTransaction()
     {
         $this->validate();
 
-        $this->folder->transactions()->create([
+        $transaction = $this->folder->transactions()->create([
             'type' => $this->type,
             'amount' => $this->amount,
             'currency_id' => $this->currency_id,
             'label' => $this->label,
             'transaction_date' => $this->transaction_date,
+            'cash_register_id' => $this->cash_register_id,
+            'user_id' => Auth::id(),
         ]);
 
-        $this->reset('type', 'amount', 'currency_id', 'label', 'transaction_date');
+        if ($transaction->cashRegister) {
+            if ($transaction->type === 'income') {
+                $transaction->cashRegister->increment('balance', $transaction->amount);
+            } else {
+                $transaction->cashRegister->decrement('balance', $transaction->amount);
+            }
+        }
+
+        $this->reset('type', 'amount', 'currency_id', 'cash_register_id', 'label', 'transaction_date');
         $this->type = 'income';
         $this->currency_id = $this->folder->currency_id;
+        $this->cash_register_id = $this->cashRegisters->first()->id ?? null;
     }
 
     public function deleteTransaction($id)
     {
         $transaction = $this->folder->transactions()->find($id);
         if ($transaction) {
+            $cash = $transaction->cashRegister;
+            if ($cash) {
+                if ($transaction->type === 'income') {
+                    $cash->decrement('balance', $transaction->amount);
+                } else {
+                    $cash->increment('balance', $transaction->amount);
+                }
+            }
             $transaction->delete();
         }
     }
 
+    public function getIncomeProperty()
+    {
+        return $this->folder->transactions()->where('type', 'income')->sum('amount');
+    }
+
+    public function getExpenseProperty()
+    {
+        return $this->folder->transactions()->where('type', 'expense')->sum('amount');
+    }
+
     public function getBalanceProperty()
     {
-        $income = $this->folder->transactions()->where('type', 'income')->sum('amount');
-        $expense = $this->folder->transactions()->where('type', 'expense')->sum('amount');
-        return $income - $expense;
+        return $this->income - $this->expense;
     }
 
     public function render()
@@ -70,6 +104,8 @@ class FolderTransactions extends Component
         return view('livewire.admin.folder.folder-transactions', [
             'transactions' => $transactions,
             'balance' => $this->balance,
+            'income' => $this->income,
+            'expense' => $this->expense,
             'folder' => $this->folder,
         ]);
     }

--- a/app/Models/CashRegister.php
+++ b/app/Models/CashRegister.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class CashRegister extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'balance',
+    ];
+
+    public function transactions()
+    {
+        return $this->hasMany(FolderTransaction::class);
+    }
+}

--- a/app/Models/FolderTransaction.php
+++ b/app/Models/FolderTransaction.php
@@ -11,6 +11,8 @@ class FolderTransaction extends Model
 
     protected $fillable = [
         'folder_id',
+        'cash_register_id',
+        'user_id',
         'type',
         'amount',
         'currency_id',
@@ -26,5 +28,15 @@ class FolderTransaction extends Model
     public function currency()
     {
         return $this->belongsTo(Currency::class);
+    }
+
+    public function cashRegister()
+    {
+        return $this->belongsTo(CashRegister::class);
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
     }
 }

--- a/database/factories/CashRegisterFactory.php
+++ b/database/factories/CashRegisterFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\CashRegister;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class CashRegisterFactory extends Factory
+{
+    protected $model = CashRegister::class;
+
+    public function definition()
+    {
+        return [
+            'name' => $this->faker->word(),
+            'balance' => 0,
+        ];
+    }
+}

--- a/database/factories/FolderTransactionFactory.php
+++ b/database/factories/FolderTransactionFactory.php
@@ -5,6 +5,8 @@ namespace Database\Factories;
 use App\Models\FolderTransaction;
 use App\Models\Folder;
 use App\Models\Currency;
+use App\Models\CashRegister;
+use App\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 class FolderTransactionFactory extends Factory
@@ -15,6 +17,8 @@ class FolderTransactionFactory extends Factory
     {
         return [
             'folder_id' => Folder::factory(),
+            'cash_register_id' => CashRegister::factory(),
+            'user_id' => User::factory(),
             'type' => $this->faker->randomElement(['income', 'expense']),
             'amount' => $this->faker->randomFloat(2, 10, 1000),
             'currency_id' => Currency::factory(),

--- a/database/migrations/2026_07_01_000000_create_cash_registers_table.php
+++ b/database/migrations/2026_07_01_000000_create_cash_registers_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('cash_registers', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->decimal('balance', 15, 2)->default(0);
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('cash_registers');
+    }
+};

--- a/database/migrations/2026_07_01_010000_add_cash_register_and_user_to_folder_transactions_table.php
+++ b/database/migrations/2026_07_01_010000_add_cash_register_and_user_to_folder_transactions_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('folder_transactions', function (Blueprint $table) {
+            $table->foreignId('cash_register_id')->nullable()->after('folder_id')
+                ->constrained()->nullOnDelete();
+            $table->foreignId('user_id')->nullable()->after('cash_register_id')
+                ->constrained()->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('folder_transactions', function (Blueprint $table) {
+            $table->dropForeign(['cash_register_id']);
+            $table->dropColumn('cash_register_id');
+            $table->dropForeign(['user_id']);
+            $table->dropColumn('user_id');
+        });
+    }
+};

--- a/resources/views/livewire/admin/cash-register/cash-register-index.blade.php
+++ b/resources/views/livewire/admin/cash-register/cash-register-index.blade.php
@@ -1,0 +1,30 @@
+<div class="w-full mx-auto bg-white p-6 rounded-xl shadow space-y-6">
+    <h2 class="text-xl font-bold">Gestion des caisses</h2>
+
+    @if (session()->has('success'))
+        <div class="bg-green-100 text-green-700 px-3 py-2 rounded">{{ session('success') }}</div>
+    @endif
+
+    <div class="flex gap-4">
+        <x-forms.input label="Nom" model="name" class="flex-1" />
+        <x-forms.input label="Solde initial" type="number" model="balance" class="w-40" />
+        <button wire:click="create" class="bg-brand-500 text-white px-4 py-2 rounded">Ajouter</button>
+    </div>
+
+    <table class="w-full mt-4 border text-sm">
+        <thead class="bg-gray-100">
+            <tr>
+                <th class="border px-2 py-1 text-left">Nom</th>
+                <th class="border px-2 py-1 text-right">Solde</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach ($cashRegisters as $register)
+                <tr>
+                    <td class="border px-2 py-1">{{ $register->name }}</td>
+                    <td class="border px-2 py-1 text-right">{{ number_format($register->balance, 2, ',', ' ') }}</td>
+                </tr>
+            @endforeach
+        </tbody>
+    </table>
+</div>

--- a/resources/views/livewire/admin/folder/folder-transactions.blade.php
+++ b/resources/views/livewire/admin/folder/folder-transactions.blade.php
@@ -12,6 +12,11 @@
                     <option value="{{ $c->id }}">{{ $c->code }}</option>
                 @endforeach
             </select>
+            <select wire:model.defer="cash_register_id" class="border rounded p-2">
+                @foreach($cashRegisters as $cr)
+                    <option value="{{ $cr->id }}">{{ $cr->name }}</option>
+                @endforeach
+            </select>
             <input type="text" wire:model.defer="label" placeholder="Libellé" class="border rounded p-2 flex-1">
             <input type="number" step="0.01" wire:model.defer="amount" placeholder="Montant" class="border rounded p-2 w-32">
             <input type="date" wire:model.defer="transaction_date" class="border rounded p-2">
@@ -27,6 +32,7 @@
                 <th class="px-3 py-2 text-left">Libellé</th>
                 <th class="px-3 py-2 text-right">Montant</th>
                 <th class="px-3 py-2 text-left">Devise</th>
+                <th class="px-3 py-2 text-left">Caisse</th>
                 <th class="px-3 py-2 text-left">Type</th>
                 <th class="px-3 py-2"></th>
             </tr>
@@ -38,6 +44,7 @@
                     <td class="px-3 py-2">{{ $transaction->label }}</td>
                     <td class="px-3 py-2 text-right">{{ number_format($transaction->amount, 2, ',', ' ') }}</td>
                     <td class="px-3 py-2">{{ $transaction->currency->code ?? '' }}</td>
+                    <td class="px-3 py-2">{{ $transaction->cashRegister->name ?? '-' }}</td>
                     <td class="px-3 py-2">{{ $transaction->type === 'income' ? 'Perçu' : 'Dépense' }}</td>
                     <td class="px-3 py-2 text-right">
                         <button wire:click="deleteTransaction({{ $transaction->id }})" class="text-red-500">Supprimer</button>
@@ -45,16 +52,28 @@
                 </tr>
             @empty
                 <tr>
-                    <td colspan="5" class="px-3 py-4 text-center text-gray-500">Aucune transaction</td>
+                    <td colspan="7" class="px-3 py-4 text-center text-gray-500">Aucune transaction</td>
                 </tr>
             @endforelse
         </tbody>
         <tfoot>
             <tr class="font-semibold">
+                <td colspan="2" class="px-3 py-2 text-right">Total perçu</td>
+                <td class="px-3 py-2 text-right">{{ number_format($income, 2, ',', ' ') }}</td>
+                <td>{{ $folder->currency->code ?? '' }}</td>
+                <td colspan="3"></td>
+            </tr>
+            <tr class="font-semibold">
+                <td colspan="2" class="px-3 py-2 text-right">Total sortie</td>
+                <td class="px-3 py-2 text-right">{{ number_format($expense, 2, ',', ' ') }}</td>
+                <td>{{ $folder->currency->code ?? '' }}</td>
+                <td colspan="3"></td>
+            </tr>
+            <tr class="font-semibold">
                 <td colspan="2" class="px-3 py-2 text-right">Solde</td>
                 <td class="px-3 py-2 text-right">{{ number_format($balance, 2, ',', ' ') }}</td>
                 <td>{{ $folder->currency->code ?? '' }}</td>
-                <td></td>
+                <td colspan="3"></td>
             </tr>
         </tfoot>
     </table>

--- a/routes/web.php
+++ b/routes/web.php
@@ -171,6 +171,10 @@ Route::get('/notifications/latest', [NotificationController::class, 'latest'])->
         Route::get('/restore/{id}', CurrencyUpdate::class)->name('restore');
     });
 
+    Route::prefix('cash-register')->name('cash-register.')->group(function () {
+        Route::get('/list', \App\Livewire\Admin\CashRegister\CashRegisterIndex::class)->name('list');
+    });
+
     // Routes pour la facturation globale
     Route::prefix('admin/global-invoices')->name('admin.global-invoices.')->group(function () {
         Route::get('/', GlobalInvoiceIndex::class)->name('index');

--- a/tests/Feature/Livewire/Admin/Folder/FolderTransactionCashRegisterTest.php
+++ b/tests/Feature/Livewire/Admin/Folder/FolderTransactionCashRegisterTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Feature\Livewire\Admin\Folder;
+
+use App\Livewire\Admin\Folder\FolderTransactions;
+use App\Models\User;
+use App\Models\Folder;
+use App\Models\Currency;
+use App\Models\CashRegister;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class FolderTransactionCashRegisterTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_transaction_updates_cash_register_balance_and_records_user(): void
+    {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
+        $currency = Currency::factory()->create(['code' => 'USD']);
+        $cashRegister = CashRegister::factory()->create(['balance' => 0]);
+        $folder = Folder::factory()->create(['currency_id' => $currency->id]);
+
+        Livewire::test(FolderTransactions::class, ['folder' => $folder])
+            ->set('cash_register_id', $cashRegister->id)
+            ->set('type', 'income')
+            ->set('label', 'Paiement')
+            ->set('amount', 100)
+            ->set('currency_id', $currency->id)
+            ->call('saveTransaction');
+
+        $this->assertDatabaseHas('folder_transactions', [
+            'folder_id' => $folder->id,
+            'cash_register_id' => $cashRegister->id,
+            'user_id' => $user->id,
+            'type' => 'income',
+            'amount' => 100,
+        ]);
+
+        $this->assertEquals(100, $cashRegister->fresh()->balance);
+    }
+}


### PR DESCRIPTION
## Summary
- add cash register model and migrations
- allow creating cash registers via Livewire
- extend folder transactions with cash register and user tracking
- update views to choose a cash register and display totals
- update factories and add feature test

## Testing
- `php` (failed: command not found)


------
https://chatgpt.com/codex/tasks/task_e_6868d4f877c0832086ba2e047e6b95b3