### PR TITLE
Add multi-currency cash registers

### DIFF
--- a/app/Livewire/Admin/CashRegister/CashRegisterIndex.php
+++ b/app/Livewire/Admin/CashRegister/CashRegisterIndex.php
@@ -4,15 +4,25 @@ namespace App\Livewire\Admin\CashRegister;
 
 use Livewire\Component;
 use App\Models\CashRegister;
+use App\Models\Currency;
 
 class CashRegisterIndex extends Component
 {
     public $name;
     public $balance = 0;
+    public $currency_id;
+    public $currencies = [];
+
+    public function mount()
+    {
+        $this->currencies = Currency::all();
+        $this->currency_id = $this->currencies->first()->id ?? null;
+    }
 
     protected $rules = [
         'name' => 'required|string|max:255',
         'balance' => 'numeric',
+        'currency_id' => 'required|exists:currencies,id',
     ];
 
     public function create()
@@ -22,16 +32,18 @@ class CashRegisterIndex extends Component
         CashRegister::create([
             'name' => $this->name,
             'balance' => $this->balance,
+            'currency_id' => $this->currency_id,
         ]);
 
-        $this->reset(['name', 'balance']);
+        $this->reset(['name', 'balance', 'currency_id']);
         session()->flash('success', 'Caisse créée avec succès.');
     }
 
     public function render()
     {
         return view('livewire.admin.cash-register.cash-register-index', [
-            'cashRegisters' => CashRegister::all(),
+            'cashRegisters' => CashRegister::with('currency')->get(),
+            'currencies' => $this->currencies,
         ]);
     }
 }

--- a/app/Models/CashRegister.php
+++ b/app/Models/CashRegister.php
@@ -12,10 +12,16 @@ class CashRegister extends Model
     protected $fillable = [
         'name',
         'balance',
+        'currency_id',
     ];
 
     public function transactions()
     {
         return $this->hasMany(FolderTransaction::class);
+    }
+
+    public function currency()
+    {
+        return $this->belongsTo(Currency::class);
     }
 }

--- a/database/factories/CashRegisterFactory.php
+++ b/database/factories/CashRegisterFactory.php
@@ -3,6 +3,7 @@
 namespace Database\Factories;
 
 use App\Models\CashRegister;
+use App\Models\Currency;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 class CashRegisterFactory extends Factory
@@ -14,6 +15,7 @@ class CashRegisterFactory extends Factory
         return [
             'name' => $this->faker->word(),
             'balance' => 0,
+            'currency_id' => Currency::factory(),
         ];
     }
 }

--- a/database/migrations/2026_07_01_020000_add_currency_id_to_cash_registers_table.php
+++ b/database/migrations/2026_07_01_020000_add_currency_id_to_cash_registers_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('cash_registers', function (Blueprint $table) {
+            $table->foreignId('currency_id')->nullable()->after('name')->constrained()->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('cash_registers', function (Blueprint $table) {
+            $table->dropForeign(['currency_id']);
+            $table->dropColumn('currency_id');
+        });
+    }
+};

--- a/resources/views/components/partials/sidebar.blade.php
+++ b/resources/views/components/partials/sidebar.blade.php
@@ -557,6 +557,13 @@
                                         </a>
                                     </li>
                                     <li>
+                                        <a href="{{ route('cash-register.list') }}" class="menu-dropdown-item group"
+                                            :class="page === 'Caisses' ? 'menu-dropdown-item-active' :
+                                                'menu-dropdown-item-inactive'">
+                                            Caisses
+                                        </a>
+                                    </li>
+                                    <li>
                                         <a href="/methodes-de-paiement" class="menu-dropdown-item group"
                                             :class="page === 'MethodesDePaiement' ? 'menu-dropdown-item-active' :
                                                 'menu-dropdown-item-inactive'">

--- a/resources/views/livewire/admin/cash-register/cash-register-index.blade.php
+++ b/resources/views/livewire/admin/cash-register/cash-register-index.blade.php
@@ -8,6 +8,12 @@
     <div class="flex gap-4">
         <x-forms.input label="Nom" model="name" class="flex-1" />
         <x-forms.input label="Solde initial" type="number" model="balance" class="w-40" />
+        <x-forms.select label="Devise" model="currency_id" class="w-40">
+            <option value="">-- Choisir --</option>
+            @foreach ($currencies as $currency)
+                <option value="{{ $currency->id }}">{{ $currency->code }}</option>
+            @endforeach
+        </x-forms.select>
         <button wire:click="create" class="bg-brand-500 text-white px-4 py-2 rounded">Ajouter</button>
     </div>
 
@@ -15,6 +21,7 @@
         <thead class="bg-gray-100">
             <tr>
                 <th class="border px-2 py-1 text-left">Nom</th>
+                <th class="border px-2 py-1">Devise</th>
                 <th class="border px-2 py-1 text-right">Solde</th>
             </tr>
         </thead>
@@ -22,6 +29,7 @@
             @foreach ($cashRegisters as $register)
                 <tr>
                     <td class="border px-2 py-1">{{ $register->name }}</td>
+                    <td class="border px-2 py-1 text-center">{{ $register->currency->code ?? '' }}</td>
                     <td class="border px-2 py-1 text-right">{{ number_format($register->balance, 2, ',', ' ') }}</td>
                 </tr>
             @endforeach

--- a/tests/Feature/Livewire/Admin/Folder/FolderTransactionCashRegisterTest.php
+++ b/tests/Feature/Livewire/Admin/Folder/FolderTransactionCashRegisterTest.php
@@ -21,7 +21,10 @@ class FolderTransactionCashRegisterTest extends TestCase
         $this->actingAs($user);
 
         $currency = Currency::factory()->create(['code' => 'USD']);
-        $cashRegister = CashRegister::factory()->create(['balance' => 0]);
+        $cashRegister = CashRegister::factory()->create([
+            'balance' => 0,
+            'currency_id' => $currency->id,
+        ]);
         $folder = Folder::factory()->create(['currency_id' => $currency->id]);
 
         Livewire::test(FolderTransactions::class, ['folder' => $folder])


### PR DESCRIPTION
## Summary
- extend cash register with currency support
- show currency dropdown when creating a register
- display currency in cash register list
- link cash register management from sidebar
- update factory, test, and add migration for currency

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868d754e2d8832093b4ac795371a792