### PR TITLE
Implement currency CRUD module

### DIFF
--- a/app/Livewire/Admin/Currency/CurrencyIndex.php
+++ b/app/Livewire/Admin/Currency/CurrencyIndex.php
@@ -8,7 +8,7 @@ use App\Models\Currency;
 class CurrencyIndex extends Component
 {
 
-    public $code, $name, $symbol;
+    public $code, $name, $symbol, $exchange_rate;
     public $currencyIdBeingUpdated = null;
 
     protected function rules()
@@ -17,6 +17,7 @@ class CurrencyIndex extends Component
             'code' => 'required|string|max:10|unique:currencies,code,' . $this->currencyIdBeingUpdated,
             'name' => 'required|string|max:255',
             'symbol' => 'nullable|string|max:10',
+            'exchange_rate' => 'required|numeric|min:0',
         ];
     }
 
@@ -28,6 +29,7 @@ class CurrencyIndex extends Component
             'code' => strtoupper($this->code),
             'name' => $this->name,
             'symbol' => $this->symbol,
+            'exchange_rate' => $this->exchange_rate,
         ]);
 
         $this->resetForm();
@@ -41,6 +43,7 @@ class CurrencyIndex extends Component
         $this->code = $currency->code;
         $this->name = $currency->name;
         $this->symbol = $currency->symbol;
+        $this->exchange_rate = $currency->exchange_rate;
     }
 
     public function update()
@@ -52,6 +55,7 @@ class CurrencyIndex extends Component
             'code' => strtoupper($this->code),
             'name' => $this->name,
             'symbol' => $this->symbol,
+            'exchange_rate' => $this->exchange_rate,
         ]);
 
         $this->resetForm();
@@ -76,6 +80,7 @@ class CurrencyIndex extends Component
         $this->code = '';
         $this->name = '';
         $this->symbol = '';
+        $this->exchange_rate = '';
         $this->currencyIdBeingUpdated = null;
     }
 

--- a/app/Livewire/Admin/Currency/CurrencyUpdate.php
+++ b/app/Livewire/Admin/Currency/CurrencyUpdate.php
@@ -2,10 +2,47 @@
 
 namespace App\Livewire\Admin\Currency;
 
+use App\Models\Currency;
 use Livewire\Component;
 
 class CurrencyUpdate extends Component
 {
+    public Currency $currency;
+
+    public $code;
+    public $name;
+    public $symbol;
+    public $exchange_rate;
+
+    public function mount(Currency $currency)
+    {
+        $this->currency = $currency;
+        $this->code = $currency->code;
+        $this->name = $currency->name;
+        $this->symbol = $currency->symbol;
+        $this->exchange_rate = $currency->exchange_rate;
+    }
+
+    protected function rules()
+    {
+        return [
+            'code' => 'required|string|max:10|unique:currencies,code,' . $this->currency->id,
+            'name' => 'required|string|max:255',
+            'symbol' => 'nullable|string|max:10',
+            'exchange_rate' => 'required|numeric|min:0',
+        ];
+    }
+
+    public function updateCurrency()
+    {
+        $data = $this->validate();
+        $this->currency->update($data);
+
+        session()->flash('success', 'Devise mise à jour avec succès.');
+
+        return redirect()->route('currency.list');
+    }
+
     public function render()
     {
         return view('livewire.admin.currency.currency-update');

--- a/resources/views/livewire/admin/currency/currency-index.blade.php
+++ b/resources/views/livewire/admin/currency/currency-index.blade.php
@@ -19,6 +19,7 @@
             <x-forms.input label="Code" model="code" placeholder="USD, CDF..." />
             <x-forms.input label="Nom" model="name" placeholder="Dollar américain" />
             <x-forms.input label="Symbole" model="symbol" placeholder="$, FC..." />
+            <x-forms.input label="Taux de change" model="exchange_rate" placeholder="1" />
         </div>
 
         <div class="flex gap-2">
@@ -38,6 +39,7 @@
                 <th class="border px-2 py-1">Code</th>
                 <th class="border px-2 py-1">Nom</th>
                 <th class="border px-2 py-1">Symbole</th>
+                <th class="border px-2 py-1">Taux</th>
                 <th class="border px-2 py-1 text-center">Par défaut</th>
                 <th class="border px-2 py-1 text-center">Actions</th>
             </tr>
@@ -48,6 +50,7 @@
                     <td class="border px-2 py-1">{{ $currency->code }}</td>
                     <td class="border px-2 py-1">{{ $currency->name }}</td>
                     <td class="border px-2 py-1">{{ $currency->symbol }}</td>
+                    <td class="border px-2 py-1">{{ number_format($currency->exchange_rate, 2) }}</td>
                     <td class="border px-2 py-1 text-center">
                         @if ($currency->is_default)
                             ✅

--- a/resources/views/livewire/admin/currency/currency-update.blade.php
+++ b/resources/views/livewire/admin/currency/currency-update.blade.php
@@ -1,3 +1,14 @@
-<div>
-    {{-- Knowing others is intelligence; knowing yourself is true wisdom. --}}
+<div class="max-w-xl mx-auto bg-white p-6 rounded-xl shadow">
+    <h2 class="text-xl font-bold mb-4">Modifier la devise</h2>
+    <x-ui.flash-message />
+    <x-ui.error-message />
+    <form wire:submit.prevent="updateCurrency" class="space-y-4">
+        <x-forms.input label="Code" model="code" placeholder="USD" />
+        <x-forms.input label="Nom" model="name" placeholder="Dollar américain" />
+        <x-forms.input label="Symbole" model="symbol" placeholder="$" />
+        <x-forms.input label="Taux de change" model="exchange_rate" placeholder="1" />
+        <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">
+            Enregistrer
+        </button>
+    </form>
 </div>

--- a/tests/Feature/Admin/CurrencyCrudTest.php
+++ b/tests/Feature/Admin/CurrencyCrudTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Models\User;
+use App\Models\Currency;
+use App\Livewire\Admin\Currency\CurrencyIndex;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use Tests\TestCase;
+
+class CurrencyCrudTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+        $this->actingAs($this->user);
+    }
+
+    /** @test */
+    public function test_currency_crud_operations(): void
+    {
+        Livewire::test(CurrencyIndex::class)
+            ->set('code', 'GBP')
+            ->set('name', 'Livre')
+            ->set('symbol', '£')
+            ->set('exchange_rate', 1.5)
+            ->call('create');
+
+        $currency = Currency::where('code', 'GBP')->first();
+        $this->assertNotNull($currency);
+
+        Livewire::test(CurrencyIndex::class)
+            ->call('edit', $currency->id)
+            ->set('code', 'GBP')
+            ->set('name', 'Livre Sterling')
+            ->set('symbol', '£')
+            ->set('exchange_rate', 1.6)
+            ->call('update');
+
+        $this->assertDatabaseHas('currencies', [
+            'id' => $currency->id,
+            'name' => 'Livre Sterling',
+            'exchange_rate' => 1.6,
+        ]);
+
+        Livewire::test(CurrencyIndex::class)
+            ->call('delete', $currency->id);
+
+        $this->assertDatabaseMissing('currencies', ['id' => $currency->id]);
+    }
+}


### PR DESCRIPTION
## Summary
- enhance currency Livewire component with exchange rate field
- add dedicated currency update component and view
- display exchange rate in currency list UI
- test currency CRUD via Livewire

## Testing
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868d8cf8f9083209f1e7dd7f45562d6