### PR TITLE
Fix currency management sidebar link

### DIFF
--- a/resources/views/components/partials/sidebar.blade.php
+++ b/resources/views/components/partials/sidebar.blade.php
@@ -550,7 +550,7 @@
                                         </a>
                                     </li>
                                     <li>
-                                        <a href="/devises" class="menu-dropdown-item group"
+                                        <a href="{{ route('currency.list') }}" class="menu-dropdown-item group"
                                             :class="page === 'Devises' ? 'menu-dropdown-item-active' :
                                                 'menu-dropdown-item-inactive'">
                                             Devises


### PR DESCRIPTION
## Summary
- update sidebar to use the proper currency list route

## Testing
- `npm test` *(fails: Missing script)*
- `phpunit --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868da3ee8948320ae6d6a943bc6b61b