### PR TITLE
Fix sanitized folder transactions PDF filename

### DIFF
--- a/app/Livewire/Admin/Folder/FolderTransactions.php
+++ b/app/Livewire/Admin/Folder/FolderTransactions.php
@@ -115,7 +115,8 @@ class FolderTransactions extends Component
             'balance' => $this->balance,
         ]);
 
-        $filename = 'Transactions_Dossier_' . $this->folder->folder_number . '.pdf';
+        $sanitizedNumber = str_replace(['/', '\\'], '-', $this->folder->folder_number);
+        $filename = 'Transactions_Dossier_' . $sanitizedNumber . '.pdf';
 
         return response()->streamDownload(
             fn () => print($pdf->output()),


### PR DESCRIPTION
## Summary
- sanitize folder number when generating PDF filename to prevent invalid characters

## Testing
- `php artisan test` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6868e56934f08320803cb9d38764cf39