### PR TITLE
Add manual backup and restore commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ KelseaSoft is a powerful and intuitive **customs agency management software** de
 - **Attach Documents**: Upload supporting files for each dossier.
 - **Generate Invoices**: Process invoices and export them as PDFs.
 - **Track Payments**: Monitor payment statuses of each invoice.
+- **Manual Backup**: Run `php artisan database:backup` to create a database dump in `storage/app/backups`. Restore with `php artisan database:restore <file>`.
 
 ## Contributing
 We welcome contributions to enhance KelseaSoft. Feel free to submit pull requests or report issues.

--- a/app/Services/Backup/BackupService.php
+++ b/app/Services/Backup/BackupService.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Services\Backup;
+
+use Exception;
+use Illuminate\Support\Str;
+
+class BackupService
+{
+    public function backup(): string
+    {
+        $connection = config('database.default');
+        $db = config("database.connections.$connection");
+
+        $timestamp = now()->format('Ymd_His');
+        $fileName = "backup_{$timestamp}.sql";
+        $path = storage_path('app/backups/' . $fileName);
+
+        if ($db['driver'] === 'mysql') {
+            $command = sprintf(
+                'mysqldump -h %s -u %s -p"%s" %s > %s',
+                $db['host'],
+                $db['username'],
+                $db['password'],
+                $db['database'],
+                $path
+            );
+        } elseif ($db['driver'] === 'pgsql') {
+            $command = sprintf(
+                'PGPASSWORD="%s" pg_dump -h %s -U %s %s > %s',
+                $db['password'],
+                $db['host'],
+                $db['username'],
+                $db['database'],
+                $path
+            );
+        } else {
+            throw new Exception('Unsupported database driver for backup.');
+        }
+
+        system($command);
+
+        return $fileName;
+    }
+
+    public function restore(string $file): void
+    {
+        $connection = config('database.default');
+        $db = config("database.connections.$connection");
+        $path = storage_path('app/backups/' . $file);
+
+        if (!file_exists($path)) {
+            throw new Exception('Backup file not found.');
+        }
+
+        if ($db['driver'] === 'mysql') {
+            $command = sprintf(
+                'mysql -h %s -u %s -p"%s" %s < %s',
+                $db['host'],
+                $db['username'],
+                $db['password'],
+                $db['database'],
+                $path
+            );
+        } elseif ($db['driver'] === 'pgsql') {
+            $command = sprintf(
+                'PGPASSWORD="%s" psql -h %s -U %s %s < %s',
+                $db['password'],
+                $db['host'],
+                $db['username'],
+                $db['database'],
+                $path
+            );
+        } else {
+            throw new Exception('Unsupported database driver for restore.');
+        }
+
+        system($command);
+    }
+}

--- a/routes/console.php
+++ b/routes/console.php
@@ -6,3 +6,22 @@ use Illuminate\Support\Facades\Artisan;
 Artisan::command('inspire', function () {
     $this->comment(Inspiring::quote());
 })->purpose('Display an inspiring quote');
+
+use App\Services\Backup\BackupService;
+
+Artisan::command('database:backup', function () {
+    $service = new BackupService();
+    $file = $service->backup();
+    $this->info('Backup saved to storage/app/backups/' . $file);
+})->purpose('Create a database backup');
+
+Artisan::command('database:restore {file}', function (string $file) {
+    $service = new BackupService();
+    try {
+        $service->restore($file);
+        $this->info('Database restored from ' . $file);
+    } catch (\Exception $e) {
+        $this->error($e->getMessage());
+    }
+})->purpose('Restore database from a backup');
+

--- a/storage/app/backups/.gitignore
+++ b/storage/app/backups/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
## Summary
- implement `BackupService` for database dump and restore
- register `database:backup` and `database:restore` console commands
- ignore backup files
- document manual backup usage in README

## Testing
- `php artisan test` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686e6206f654832099d5dc3c10a71551