### PR TITLE
Add backup management UI

### DIFF
--- a/app/Livewire/Admin/Backup/BackupIndex.php
+++ b/app/Livewire/Admin/Backup/BackupIndex.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Livewire\Admin\Backup;
+
+use Livewire\Component;
+use Illuminate\Support\Facades\Storage;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+use App\Services\Backup\BackupService;
+
+class BackupIndex extends Component
+{
+    public function createBackup(): void
+    {
+        $service = new BackupService();
+        $file = $service->backup();
+        session()->flash('success', 'Sauvegarde créée : ' . $file);
+    }
+
+    public function restoreBackup(string $file): void
+    {
+        try {
+            $service = new BackupService();
+            $service->restore($file);
+            session()->flash('success', 'Base restaurée depuis ' . $file);
+        } catch (\Exception $e) {
+            session()->flash('error', $e->getMessage());
+        }
+    }
+
+    public function deleteBackup(string $file): void
+    {
+        Storage::disk('local')->delete('backups/' . $file);
+        session()->flash('success', 'Sauvegarde supprimée.');
+    }
+
+    public function download(string $file): StreamedResponse
+    {
+        $path = storage_path('app/backups/' . $file);
+        return response()->download($path);
+    }
+
+    public function render()
+    {
+        $files = collect(Storage::disk('local')->files('backups'))
+            ->filter(fn ($f) => str_ends_with($f, '.sql'))
+            ->map(fn ($f) => basename($f))
+            ->sortDesc();
+
+        return view('livewire.admin.backup.backup-index', ['files' => $files]);
+    }
+}

--- a/resources/views/components/partials/sidebar.blade.php
+++ b/resources/views/components/partials/sidebar.blade.php
@@ -651,6 +651,11 @@
                                             Archivages
                                         </a>
                                     </li>
+                                    <li>
+                                        <a href="{{ route('backups.index') }}" class="menu-dropdown-item group">
+                                            Sauvegardes
+                                        </a>
+                                    </li>
                                 </ul>
                             </div>
                             <!-- Dropdown Menu End -->

--- a/resources/views/livewire/admin/backup/backup-index.blade.php
+++ b/resources/views/livewire/admin/backup/backup-index.blade.php
@@ -1,0 +1,39 @@
+<div class="p-6 bg-white rounded shadow space-y-4">
+    <h2 class="text-xl font-bold">💾 Sauvegardes</h2>
+
+    @if (session()->has('success'))
+        <div class="bg-green-100 text-green-700 px-3 py-2 rounded">{{ session('success') }}</div>
+    @endif
+    @if (session()->has('error'))
+        <div class="bg-red-100 text-red-700 px-3 py-2 rounded">{{ session('error') }}</div>
+    @endif
+
+    <button wire:click="createBackup" class="bg-violet-600 text-white px-4 py-2 rounded hover:bg-violet-700">
+        ➕ Nouvelle sauvegarde
+    </button>
+
+    <table class="w-full mt-4 border text-sm">
+        <thead class="bg-gray-100">
+            <tr>
+                <th class="border px-2 py-1">Fichier</th>
+                <th class="border px-2 py-1">Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            @forelse ($files as $file)
+                <tr>
+                    <td class="border px-2 py-1">{{ $file }}</td>
+                    <td class="border px-2 py-1 space-x-2">
+                        <a href="{{ route('backups.download', $file) }}" class="text-blue-600 hover:underline">Télécharger</a>
+                        <button wire:click="restoreBackup('{{ $file }}')" class="text-green-600 hover:underline">Restaurer</button>
+                        <button wire:click="deleteBackup('{{ $file }}')" class="text-red-600 hover:underline">Supprimer</button>
+                    </td>
+                </tr>
+            @empty
+                <tr>
+                    <td colspan="2" class="text-center py-4 text-gray-500">Aucune sauvegarde</td>
+                </tr>
+            @endforelse
+        </tbody>
+    </table>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -36,6 +36,7 @@ use App\Livewire\Admin\Invoices\InvoiceTrash;
 use App\Livewire\Admin\Invoices\GlobalInvoiceIndex; // Ajout pour GlobalInvoiceIndex
 use App\Livewire\Admin\Invoices\GlobalInvoiceShow;  // Ajout pour GlobalInvoiceShow
 use App\Livewire\Admin\Archive\ArchiveIndex;
+use App\Livewire\Admin\Backup\BackupIndex;
 
 use App\Livewire\Admin\Currency\CurrencyIndex;
 use App\Livewire\Admin\Currency\CurrencyUpdate;
@@ -204,6 +205,11 @@ Route::get('/notifications/latest', [NotificationController::class, 'latest'])->
     });
 
     Route::get('/archives', ArchiveIndex::class)->name('archives.index');
+
+    Route::prefix('backups')->name('backups.')->group(function () {
+        Route::get('/', BackupIndex::class)->name('index');
+        Route::get('/download/{file}', [BackupIndex::class, 'download'])->name('download');
+    });
 
     // Admin Routes for User, Role, Permission Management
     Route::prefix('admin')->name('admin.')->group(function () {


### PR DESCRIPTION
## Summary
- add a Livewire component to manage database backups
- list existing backups, create, restore, delete and download from UI
- expose routes and menu entry

## Testing
- `composer install` *(fails: command not found)*
- `./vendor/bin/pest` *(fails: file not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e64931b488320863fa10c0c01c78f