### PR TITLE
Implement printable calculation sheet

### DIFF
--- a/app/Livewire/Admin/Folder/FolderExtraFields.php
+++ b/app/Livewire/Admin/Folder/FolderExtraFields.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Livewire\Admin\Folder;
+
+use Livewire\Component;
+use App\Models\Folder;
+
+class FolderExtraFields extends Component
+{
+    public Folder $folder;
+
+    public $scelle_number;
+    public $manifest_number;
+    public $incoterm;
+    public $customs_regime;
+    public $additional_code;
+    public $quotation_date;
+    public $opening_date;
+    public $entry_point;
+
+    public function mount(Folder $folder): void
+    {
+        $this->folder = $folder;
+        $this->fill($folder->only([
+            'scelle_number',
+            'manifest_number',
+            'incoterm',
+            'customs_regime',
+            'additional_code',
+            'quotation_date',
+            'opening_date',
+            'entry_point',
+        ]));
+    }
+
+    protected function rules(): array
+    {
+        return [
+            'scelle_number' => 'nullable|string|max:255',
+            'manifest_number' => 'nullable|string|max:255',
+            'incoterm' => 'nullable|string|max:255',
+            'customs_regime' => 'nullable|string|max:255',
+            'additional_code' => 'nullable|string|max:255',
+            'quotation_date' => 'nullable|date',
+            'opening_date' => 'nullable|date',
+            'entry_point' => 'nullable|string|max:255',
+        ];
+    }
+
+    public function save(): void
+    {
+        $data = $this->validate();
+        $this->folder->update($data);
+        session()->flash('success', 'Informations mises à jour');
+    }
+
+    public function render()
+    {
+        return view('livewire.admin.folder.partials.folder-extra-fields');
+    }
+}

--- a/app/Livewire/Admin/Folder/FolderLinesForm.php
+++ b/app/Livewire/Admin/Folder/FolderLinesForm.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Livewire\Admin\Folder;
+
+use Livewire\Component;
+use App\Models\Folder;
+use App\Models\FolderLine;
+
+class FolderLinesForm extends Component
+{
+    public Folder $folder;
+
+    public array $line = [
+        'position_code' => '',
+        'description' => '',
+        'invoice_number' => '',
+        'colis' => '',
+        'emballage' => '',
+        'gross_weight' => null,
+        'net_weight' => null,
+        'fob_amount' => null,
+        'license_code' => '',
+        'fxi' => '',
+    ];
+
+    public function mount(Folder $folder): void
+    {
+        $this->folder = $folder->load('lines');
+    }
+
+    protected function rules(): array
+    {
+        return [
+            'line.position_code' => 'nullable|string|max:255',
+            'line.description' => 'nullable|string|max:255',
+            'line.invoice_number' => 'nullable|string|max:255',
+            'line.colis' => 'nullable|string|max:255',
+            'line.emballage' => 'nullable|string|max:255',
+            'line.gross_weight' => 'nullable|numeric',
+            'line.net_weight' => 'nullable|numeric',
+            'line.fob_amount' => 'nullable|numeric',
+            'line.license_code' => 'nullable|string|max:255',
+            'line.fxi' => 'nullable|string|max:255',
+        ];
+    }
+
+    public function addLine(): void
+    {
+        $data = $this->validate()['line'];
+        $this->folder->lines()->create($data);
+        $this->folder->refresh();
+        $this->reset('line');
+        session()->flash('success', 'Ligne ajoutée');
+    }
+
+    public function deleteLine(int $id): void
+    {
+        $this->folder->lines()->where('id', $id)->delete();
+        $this->folder->refresh();
+    }
+
+    public function render()
+    {
+        return view('livewire.admin.folder.partials.folder-lines-form');
+    }
+}

--- a/app/Livewire/Pages/Folder/PrintableCalculationSheet.php
+++ b/app/Livewire/Pages/Folder/PrintableCalculationSheet.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Livewire\Pages\Folder;
+
+use Livewire\Component;
+use App\Models\Folder;
+
+class PrintableCalculationSheet extends Component
+{
+    public Folder $folder;
+
+    public function mount(Folder $folder): void
+    {
+        $this->folder = $folder->load(['invoice', 'lines', 'company', 'customsOffice']);
+    }
+
+    public function render()
+    {
+        return view('livewire.pages.folder.printable-calculation-sheet');
+    }
+}

--- a/app/Models/Folder.php
+++ b/app/Models/Folder.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Casts\Attribute;
 use App\Models\Currency;
 use App\Models\DocumentType;
 use App\Models\FolderTransaction;
+use App\Models\FolderLine;
 use App\Traits\Auditable;
 use Kyslik\ColumnSortable\Sortable;
 
@@ -54,11 +55,21 @@ class Folder extends Model
         'bivac_code',
         'license_id',
         'company_id',
-        
+        'scelle_number',
+        'manifest_number',
+        'incoterm',
+        'customs_regime',
+        'additional_code',
+        'quotation_date',
+        'opening_date',
+        'entry_point',
+
     ];
 
     protected $casts = [
         'arrival_border_date' => 'date',
+        'quotation_date' => 'date',
+        'opening_date' => 'date',
         'weight' => 'float',
         'quantity' => 'float',
         'fob_amount' => 'float',
@@ -161,6 +172,11 @@ class Folder extends Model
     public function invoice()
     {
         return $this->hasOne(\App\Models\Invoice::class);
+    }
+
+    public function lines()
+    {
+        return $this->hasMany(FolderLine::class);
     }
 
     /**

--- a/app/Models/FolderLine.php
+++ b/app/Models/FolderLine.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class FolderLine extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'folder_id',
+        'position_code',
+        'description',
+        'invoice_number',
+        'colis',
+        'emballage',
+        'gross_weight',
+        'net_weight',
+        'fob_amount',
+        'license_code',
+        'fxi',
+    ];
+
+    public function folder()
+    {
+        return $this->belongsTo(Folder::class);
+    }
+}

--- a/database/migrations/2026_07_28_000001_add_folder_id_to_invoices_table.php
+++ b/database/migrations/2026_07_28_000001_add_folder_id_to_invoices_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('invoices', function (Blueprint $table) {
+            if (!Schema::hasColumn('invoices', 'folder_id')) {
+                $table->foreignId('folder_id')->nullable()->after('id')->constrained('folders')->nullOnDelete();
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('invoices', function (Blueprint $table) {
+            if (Schema::hasColumn('invoices', 'folder_id')) {
+                $table->dropForeign(['folder_id']);
+                $table->dropColumn('folder_id');
+            }
+        });
+    }
+};

--- a/database/migrations/2026_07_28_000002_create_folder_lines_table.php
+++ b/database/migrations/2026_07_28_000002_create_folder_lines_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('folder_lines', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('folder_id')->constrained()->onDelete('cascade');
+            $table->string('position_code')->nullable();
+            $table->string('description')->nullable();
+            $table->string('invoice_number')->nullable();
+            $table->string('colis')->nullable();
+            $table->string('emballage')->nullable();
+            $table->decimal('gross_weight', 10, 2)->nullable();
+            $table->decimal('net_weight', 10, 2)->nullable();
+            $table->decimal('fob_amount', 15, 2)->nullable();
+            $table->string('license_code')->nullable();
+            $table->string('fxi')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('folder_lines');
+    }
+};

--- a/database/migrations/2026_07_28_000003_add_extra_fields_to_folders_table.php
+++ b/database/migrations/2026_07_28_000003_add_extra_fields_to_folders_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('folders', function (Blueprint $table) {
+            $table->string('scelle_number')->nullable();
+            $table->string('manifest_number')->nullable();
+            $table->string('incoterm')->nullable();
+            $table->string('customs_regime')->nullable();
+            $table->string('additional_code')->nullable();
+            $table->date('quotation_date')->nullable();
+            $table->date('opening_date')->nullable();
+            $table->string('entry_point')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('folders', function (Blueprint $table) {
+            $table->dropColumn([
+                'scelle_number',
+                'manifest_number',
+                'incoterm',
+                'customs_regime',
+                'additional_code',
+                'quotation_date',
+                'opening_date',
+                'entry_point',
+            ]);
+        });
+    }
+};

--- a/resources/views/livewire/admin/folder/folder-show.blade.php
+++ b/resources/views/livewire/admin/folder/folder-show.blade.php
@@ -93,6 +93,14 @@
                     ['label' => 'Arrival Border Date', 'value' => optional($folder->arrival_border_date)->format('d/m/Y') ?? '—'],
                     ['label' => 'License Code', 'value' => $folder->license_code ?? '—'],
                     ['label' => 'BIVAC Code', 'value' => $folder->bivac_code ?? '—'],
+                    ['label' => 'Scellé', 'value' => $folder->scelle_number ?? '—'],
+                    ['label' => 'Manifeste', 'value' => $folder->manifest_number ?? '—'],
+                    ['label' => 'Incoterm', 'value' => $folder->incoterm ?? '—'],
+                    ['label' => 'Régime', 'value' => $folder->customs_regime ?? '—'],
+                    ['label' => 'Code additionnel', 'value' => $folder->additional_code ?? '—'],
+                    ['label' => 'Date cotation', 'value' => optional($folder->quotation_date)->format('d/m/Y') ?? '—'],
+                    ['label' => 'Date ouverture', 'value' => optional($folder->opening_date)->format('d/m/Y') ?? '—'],
+                    ['label' => "Point d'entrée", 'value' => $folder->entry_point ?? '—'],
                     ['label' => 'TR8 Number', 'value' => $folder->tr8_number ?? '—'],
                     ['label' => 'TR8 Date', 'value' => optional($folder->tr8_date)->format('d/m/Y') ?? '—'],
                     ['label' => 'T1 Number', 'value' => $folder->t1_number ?? '—'],
@@ -155,6 +163,14 @@
             <p class="text-xs text-gray-600 dark:text-gray-400 mt-2">
                 {{ $folder->progress_percentage }}% terminé
             </p>
+        </div>
+
+        <div class="mt-6">
+            @livewire('admin.folder.folder-extra-fields', ['folder' => $folder], key('extra-fields-' . $folder->id))
+        </div>
+
+        <div class="mt-6">
+            @livewire('admin.folder.folder-lines-form', ['folder' => $folder], key('lines-form-' . $folder->id))
         </div>
     </div>
 </div>

--- a/resources/views/livewire/admin/folder/partials/folder-extra-fields.blade.php
+++ b/resources/views/livewire/admin/folder/partials/folder-extra-fields.blade.php
@@ -1,0 +1,14 @@
+<div class="space-y-4">
+    <h4 class="text-md font-semibold text-gray-700 dark:text-gray-200">Informations complémentaires</h4>
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-2">
+        <input type="text" wire:model.defer="scelle_number" placeholder="N° scellé" class="border rounded px-2 py-1">
+        <input type="text" wire:model.defer="manifest_number" placeholder="N° manifeste" class="border rounded px-2 py-1">
+        <input type="text" wire:model.defer="incoterm" placeholder="Incoterm" class="border rounded px-2 py-1">
+        <input type="text" wire:model.defer="customs_regime" placeholder="Régime" class="border rounded px-2 py-1">
+        <input type="text" wire:model.defer="additional_code" placeholder="Code additionnel" class="border rounded px-2 py-1">
+        <input type="date" wire:model.defer="quotation_date" class="border rounded px-2 py-1">
+        <input type="date" wire:model.defer="opening_date" class="border rounded px-2 py-1">
+        <input type="text" wire:model.defer="entry_point" placeholder="Point d'entrée" class="border rounded px-2 py-1">
+    </div>
+    <button wire:click="save" class="mt-2 px-4 py-2 bg-indigo-600 text-white rounded">Enregistrer</button>
+</div>

--- a/resources/views/livewire/admin/folder/partials/folder-lines-form.blade.php
+++ b/resources/views/livewire/admin/folder/partials/folder-lines-form.blade.php
@@ -1,0 +1,42 @@
+<div class="space-y-4">
+    <h4 class="text-md font-semibold text-gray-700 dark:text-gray-200">Lignes de cotation</h4>
+
+    <table class="w-full text-sm border border-gray-200">
+        <thead class="bg-gray-100">
+            <tr>
+                <th class="border px-2 py-1">Position</th>
+                <th class="border px-2 py-1">Description</th>
+                <th class="border px-2 py-1">Colis</th>
+                <th class="border px-2 py-1">Poids Brut</th>
+                <th class="border px-2 py-1">Poids Net</th>
+                <th class="border px-2 py-1">FOB</th>
+                <th class="border px-2 py-1"></th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach($folder->lines as $l)
+                <tr>
+                    <td class="border px-2 py-1">{{ $l->position_code }}</td>
+                    <td class="border px-2 py-1">{{ $l->description }}</td>
+                    <td class="border px-2 py-1">{{ $l->colis }}</td>
+                    <td class="border px-2 py-1 text-right">{{ number_format($l->gross_weight,2) }}</td>
+                    <td class="border px-2 py-1 text-right">{{ number_format($l->net_weight,2) }}</td>
+                    <td class="border px-2 py-1 text-right">{{ number_format($l->fob_amount,2) }}</td>
+                    <td class="border px-2 py-1 text-center">
+                        <button wire:click="deleteLine({{ $l->id }})" class="text-red-600">✖</button>
+                    </td>
+                </tr>
+            @endforeach
+        </tbody>
+    </table>
+
+    <div class="grid grid-cols-2 md:grid-cols-3 gap-2">
+        <input type="text" wire:model.defer="line.position_code" placeholder="Position" class="border rounded px-2 py-1">
+        <input type="text" wire:model.defer="line.description" placeholder="Description" class="border rounded px-2 py-1">
+        <input type="text" wire:model.defer="line.colis" placeholder="Colis" class="border rounded px-2 py-1">
+        <input type="number" step="0.01" wire:model.defer="line.gross_weight" placeholder="Poids Brut" class="border rounded px-2 py-1">
+        <input type="number" step="0.01" wire:model.defer="line.net_weight" placeholder="Poids Net" class="border rounded px-2 py-1">
+        <input type="number" step="0.01" wire:model.defer="line.fob_amount" placeholder="FOB" class="border rounded px-2 py-1">
+    </div>
+    <button wire:click="addLine" class="mt-2 px-4 py-2 bg-indigo-600 text-white rounded">Ajouter</button>
+</div>

--- a/resources/views/livewire/pages/folder/printable-calculation-sheet.blade.php
+++ b/resources/views/livewire/pages/folder/printable-calculation-sheet.blade.php
@@ -1,0 +1,46 @@
+<div class="max-w-5xl mx-auto bg-white p-6 rounded-xl shadow">
+    <h1 class="text-xl font-bold mb-4">Feuille de calcul - Dossier {{ $folder->folder_number }}</h1>
+
+    <div class="grid grid-cols-2 gap-4 text-sm mb-6">
+        <div><strong>Client :</strong> {{ $folder->company?->name ?? $folder->client }}</div>
+        <div><strong>Bureau de douane :</strong> {{ $folder->customsOffice?->name }}</div>
+        <div><strong>Conteneur :</strong> {{ $folder->container_number }}</div>
+        <div><strong>Poids :</strong> {{ number_format($folder->weight,2) }} kg</div>
+    </div>
+
+    @if($folder->invoice)
+    <h2 class="text-lg font-semibold mb-2">Montants</h2>
+    <div class="grid grid-cols-2 gap-4 text-sm mb-6">
+        <div><strong>FOB :</strong> {{ number_format($folder->invoice->fob_amount,2) }} USD</div>
+        <div><strong>Assurance :</strong> {{ number_format($folder->invoice->insurance_amount,2) }} USD</div>
+        <div><strong>Fret :</strong> {{ number_format($folder->invoice->freight_amount,2) }} USD</div>
+        <div><strong>CIF :</strong> {{ number_format($folder->invoice->cif_amount,2) }} USD</div>
+    </div>
+    @endif
+
+    <h2 class="text-lg font-semibold mb-2">Lignes de cotation</h2>
+    <table class="w-full text-sm border border-gray-200">
+        <thead class="bg-gray-100">
+            <tr>
+                <th class="border px-2 py-1">Position</th>
+                <th class="border px-2 py-1">Description</th>
+                <th class="border px-2 py-1">Colis</th>
+                <th class="border px-2 py-1 text-right">Poids Brut</th>
+                <th class="border px-2 py-1 text-right">Poids Net</th>
+                <th class="border px-2 py-1 text-right">FOB</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach($folder->lines as $line)
+            <tr>
+                <td class="border px-2 py-1">{{ $line->position_code }}</td>
+                <td class="border px-2 py-1">{{ $line->description }}</td>
+                <td class="border px-2 py-1">{{ $line->colis }}</td>
+                <td class="border px-2 py-1 text-right">{{ number_format($line->gross_weight,2) }}</td>
+                <td class="border px-2 py-1 text-right">{{ number_format($line->net_weight,2) }}</td>
+                <td class="border px-2 py-1 text-right">{{ number_format($line->fob_amount,2) }}</td>
+            </tr>
+            @endforeach
+        </tbody>
+    </table>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -90,6 +90,8 @@ Route::get('/notifications/latest', [NotificationController::class, 'latest'])->
         Route::get('/edit/{id}', FolderEdit::class)->name('edit');
         Route::get('/list', FolderList::class)->name('list');
         Route::get('/show/{id}', FolderShow::class)->name('show');
+        Route::get('/{folder}/feuille-de-calcul', \App\Livewire\Pages\Folder\PrintableCalculationSheet::class)
+            ->name('calculation');
         Route::get('/{folder}/transactions', \App\Livewire\Admin\Folder\FolderTransactions::class)->name('transactions');
         Route::get('/{folder}/transactions/download', [\App\Livewire\Admin\Folder\FolderTransactions::class, 'downloadPdf'])->name('transactions.download');
         Route::get('/transactions', \App\Livewire\Admin\Folder\FolderTransactionIndex::class)->name('transactions.index');


### PR DESCRIPTION
## Summary
- add folder_lines table
- add nullable customs fields to folders
- link invoices to folders via migration
- create FolderLine model and relationships
- allow editing extra folder info and lines from show page
- add PrintableCalculationSheet page and route

## Testing
- `php artisan test` *(fails: vendor autoload missing)*

------
https://chatgpt.com/codex/tasks/task_e_688739b30a488320806b788b654bb506