### PR TITLE
Add dual download options for global invoices

### DIFF
--- a/app/Livewire/Admin/Invoices/GlobalInvoiceShow.php
+++ b/app/Livewire/Admin/Invoices/GlobalInvoiceShow.php
@@ -38,16 +38,27 @@ class GlobalInvoiceShow extends Component
         $this->globalInvoice->load(['globalInvoiceItems', 'company', 'invoices']);
     }
 
-    public function downloadPdf(): StreamedResponse
+    public function downloadPdf1(): StreamedResponse
     {
-        $filename = 'Facture_Globale_' . $this->globalInvoice->global_invoice_number . '.pdf';
-
+        $filename = 'Facture_Globale_' . $this->globalInvoice->global_invoice_number . '_1.pdf';
 
         $pdf = Pdf::loadView('pdf.global_invoice', [
             'globalInvoice' => $this->globalInvoice,
         ]);
-        // La vue 'pdf.global_invoice' doit être créée.
-        // Elle recevra la variable $globalInvoice contenant l'objet GlobalInvoice avec ses relations chargées.
+
+        return response()->streamDownload(
+            fn() => print($pdf->output()),
+            $filename
+        );
+    }
+
+    public function downloadPdf2(): StreamedResponse
+    {
+        $filename = 'Facture_Globale_' . $this->globalInvoice->global_invoice_number . '_2.pdf';
+
+        $pdf = Pdf::loadView('pdf.global_invoice', [
+            'globalInvoice' => $this->globalInvoice,
+        ]);
 
         return response()->streamDownload(
             fn() => print($pdf->output()),

--- a/resources/views/livewire/admin/invoices/global-invoice-show.blade.php
+++ b/resources/views/livewire/admin/invoices/global-invoice-show.blade.php
@@ -7,9 +7,9 @@
                         class="text-blue-600">{{ $globalInvoice->global_invoice_number }}</span>
                 </h1>
                 <div class="text-right">
-                    <button wire:click="downloadPdf"
+                    <button wire:click="downloadPdf1"
                         class="px-4 py-2 bg-green-500 hover:bg-green-600 text-white font-semibold rounded-lg shadow-md focus:outline-none focus:ring-2 focus:ring-green-400 focus:ring-opacity-75 transition duration-150 ease-in-out">
-                        <svg wire:loading wire:target="downloadPdf" class="animate-spin -ml-1 mr-3 h-5 w-5 text-white"
+                        <svg wire:loading wire:target="downloadPdf1" class="animate-spin -ml-1 mr-3 h-5 w-5 text-white"
                             xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
                             <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor"
                                 stroke-width="4"></circle>
@@ -17,8 +17,22 @@
                                 d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z">
                             </path>
                         </svg>
-                        <span wire:loading.remove wire:target="downloadPdf">Télécharger PDF</span>
-                        <span wire:loading wire:target="downloadPdf">Téléchargement...</span>
+                        <span wire:loading.remove wire:target="downloadPdf1">Téléchargement 1</span>
+                        <span wire:loading wire:target="downloadPdf1">Téléchargement...</span>
+                    </button>
+
+                    <button wire:click="downloadPdf2"
+                        class="ml-2 px-4 py-2 bg-green-500 hover:bg-green-600 text-white font-semibold rounded-lg shadow-md focus:outline-none focus:ring-2 focus:ring-green-400 focus:ring-opacity-75 transition duration-150 ease-in-out">
+                        <svg wire:loading wire:target="downloadPdf2" class="animate-spin -ml-1 mr-3 h-5 w-5 text-white"
+                            xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor"
+                                stroke-width="4"></circle>
+                            <path class="opacity-75" fill="currentColor"
+                                d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z">
+                            </path>
+                        </svg>
+                        <span wire:loading.remove wire:target="downloadPdf2">Téléchargement 2</span>
+                        <span wire:loading wire:target="downloadPdf2">Téléchargement...</span>
                     </button>
 
                     <a href="{{ route('admin.global-invoices.edit', $globalInvoice->id) }}"
@@ -27,7 +41,7 @@
                     </a>
 
                     <button wire:click="exportSummary"
-                        class="ml-2 px-4 py-2 bg-blue-500 hover:bg-blue-600 text-white font-semibold rounded-lg shadow-md focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-opacity-75 transition duration-150 ease-in-out">
+                        class="ml-2 px-4 py-2 bg-blue-500 hover:bg-blue-600 text-white font-semibold rounded-lg shadow-md focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-opacity-75 transition durée-150 ease-in-out">
                         <svg wire:loading wire:target="exportSummary" class="animate-spin -ml-1 mr-3 h-5 w-5 text-white"
                             xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
                             <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor"
@@ -40,9 +54,16 @@
                         <span wire:loading wire:target="exportSummary">Export...</span>
                     </button>
 
-                
-                    {{-- Barre de progression lors de la génération du PDF --}}
-                    <div wire:loading wire:target="downloadPdf" class="mt-2">
+                    {{-- Barre de progression lors de la génération du PDF 1 --}}
+                    <div wire:loading wire:target="downloadPdf1" class="mt-2">
+                        <div class="w-full bg-gray-200 rounded-full h-2.5 overflow-hidden">
+                            <div class="bg-green-500 h-2.5 rounded-full animate-pulse w-full"></div>
+                        </div>
+                        <p class="text-xs text-gray-600 mt-1">Génération du PDF...</p>
+                    </div>
+
+                    {{-- Barre de progression lors de la génération du PDF 2 --}}
+                    <div wire:loading wire:target="downloadPdf2" class="mt-2">
                         <div class="w-full bg-gray-200 rounded-full h-2.5 overflow-hidden">
                             <div class="bg-green-500 h-2.5 rounded-full animate-pulse w-full"></div>
                         </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -183,7 +183,8 @@ Route::get('/notifications/latest', [NotificationController::class, 'latest'])->
     Route::prefix('admin/global-invoices')->name('admin.global-invoices.')->group(function () {
         Route::get('/', GlobalInvoiceIndex::class)->name('index');
         Route::get('/{globalInvoice}', GlobalInvoiceShow::class)->name('show');
-        Route::get('/{globalInvoice}/download', [GlobalInvoiceShow::class, 'downloadPdf'])->name('download');
+        Route::get('/{globalInvoice}/download1', [GlobalInvoiceShow::class, 'downloadPdf1'])->name('download1');
+        Route::get('/{globalInvoice}/download2', [GlobalInvoiceShow::class, 'downloadPdf2'])->name('download2');
         Route::get('/{globalInvoice}/edit', \App\Livewire\Admin\Invoices\EditGlobalInvoice::class)->name('edit');
     });
 

--- a/tests/Feature/Admin/GlobalInvoiceManagementTest.php
+++ b/tests/Feature/Admin/GlobalInvoiceManagementTest.php
@@ -223,15 +223,26 @@ class GlobalInvoiceManagementTest extends TestCase
     }
 
     /** @test */
-    public function test_can_download_global_invoice_pdf(): void
+    public function test_can_download_global_invoice_pdf_1(): void
     {
         $globalInvoice = GlobalInvoice::factory()->for($this->company)->create();
 
-        $response = $this->get(route('admin.global-invoices.download', $globalInvoice));
+        $response = $this->get(route('admin.global-invoices.download1', $globalInvoice));
 
         $response->assertStatus(200);
         $response->assertHeader('Content-Type', 'application/pdf');
-        $response->assertHeader('Content-Disposition', 'attachment; filename="Facture_Globale_' . $globalInvoice->global_invoice_number . '.pdf"');
+        $response->assertHeader('Content-Disposition', 'attachment; filename="Facture_Globale_' . $globalInvoice->global_invoice_number . '_1.pdf"');
+    }
+
+    public function test_can_download_global_invoice_pdf_2(): void
+    {
+        $globalInvoice = GlobalInvoice::factory()->for($this->company)->create();
+
+        $response = $this->get(route('admin.global-invoices.download2', $globalInvoice));
+
+        $response->assertStatus(200);
+        $response->assertHeader('Content-Type', 'application/pdf');
+        $response->assertHeader('Content-Disposition', 'attachment; filename="Facture_Globale_' . $globalInvoice->global_invoice_number . '_2.pdf"');
     }
 
     /** @test */


### PR DESCRIPTION
## Summary
- add separate `download1` and `download2` routes for global invoice PDFs
- show two download buttons on the global invoice page with individual progress indicators
- expand tests to cover both download endpoints

## Testing
- `composer install --no-interaction` *(failed: curl error 56 while downloading packages, response 403)*
- `php artisan test` *(not run: dependencies installation failed)*

------
https://chatgpt.com/codex/tasks/task_e_6891eba894f48320a4524bf0f61e6265