### PR TITLE
Add payment tracking for global invoices

### DIFF
--- a/app/Models/GlobalInvoice.php
+++ b/app/Models/GlobalInvoice.php
@@ -18,6 +18,13 @@ class GlobalInvoice extends Model
         'due_date',
         'total_amount',
         'notes',
+        'is_paid',
+    ];
+
+    protected $casts = [
+        'issue_date' => 'date',
+        'due_date' => 'date',
+        'is_paid' => 'boolean',
     ];
 
     /**

--- a/app/Services/Invoice/GlobalInvoiceService.php
+++ b/app/Services/Invoice/GlobalInvoiceService.php
@@ -166,6 +166,7 @@ class GlobalInvoiceService
                 'due_date' => null, // À définir selon la logique métier, ex: issue_date + 30 jours
                 'total_amount' => $totalGlobalAmount,
                 'notes' => 'Facture globale générée automatiquement.', // Optionnel
+                'is_paid' => false,
             ]);
 
             foreach ($aggregatedItems as $aggItemData) {

--- a/database/migrations/2025_06_02_160000_add_is_paid_to_global_invoices_table.php
+++ b/database/migrations/2025_06_02_160000_add_is_paid_to_global_invoices_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('global_invoices', function (Blueprint $table) {
+            $table->boolean('is_paid')->default(false)->after('notes');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('global_invoices', function (Blueprint $table) {
+            $table->dropColumn('is_paid');
+        });
+    }
+};

--- a/resources/views/livewire/admin/dashboard/dashboard.blade.php
+++ b/resources/views/livewire/admin/dashboard/dashboard.blade.php
@@ -233,6 +233,7 @@
                                                         <th class="px-4 py-3 text-left text-sm font-semibold text-slate-600 dark:text-slate-300">Client/Compagnie</th>
                                                         <th class="px-4 py-3 text-right text-sm font-semibold text-slate-600 dark:text-slate-300">Montant Total</th>
                                                         <th class="px-4 py-3 text-left text-sm font-semibold text-slate-600 dark:text-slate-300">Date Création</th>
+                                                        <th class="px-4 py-3 text-center text-sm font-semibold text-slate-600 dark:text-slate-300">Statut</th>
                                                         <th class="px-4 py-3 text-center text-sm font-semibold text-slate-600 dark:text-slate-300">Actions</th>
                                                     </tr>
                                                 </thead>
@@ -243,6 +244,7 @@
                                                             <td class="px-4 py-3 text-sm text-slate-500 dark:text-slate-400">{{ $globalInvoice->company?->name ?? 'N/A' }}</td>
                                                             <td class="px-4 py-3 text-right text-sm font-medium text-slate-700 dark:text-slate-200">{{ number_format($globalInvoice->total_amount, 2, ',', ' ') }} {{-- Devise --}}</td>
                                                             <td class="px-4 py-3 text-sm text-slate-500 dark:text-slate-400">{{ $globalInvoice->created_at->format('d/m/Y') }}</td>
+                                                            <td class="px-4 py-3 text-center text-sm text-slate-500 dark:text-slate-400">{{ $globalInvoice->is_paid ? 'Payée' : 'En attente' }}</td>
                                                             <td class="px-4 py-3 text-center">
                                                                 <a href="{{ route('admin.global-invoices.show', $globalInvoice->id) }}" class="text-sm font-medium text-primary hover:underline">Voir</a>
                                                             </td>

--- a/resources/views/livewire/admin/invoices/global-invoice-index.blade.php
+++ b/resources/views/livewire/admin/invoices/global-invoice-index.blade.php
@@ -27,6 +27,9 @@
                             Montant Total
                         </th>
                         <th scope="col" class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">
+                            Statut
+                        </th>
+                        <th scope="col" class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">
                             Actions
                         </th>
                     </tr>
@@ -46,6 +49,9 @@
                             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 text-right">
                                 {{ number_format($globalInvoice->total_amount, 2) }} {{-- Supposant que la devise est cohérente ou gérée ailleurs --}}
                             </td>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 text-center">
+                                {{ $globalInvoice->is_paid ? 'Payée' : 'En attente' }}
+                            </td>
                             <td class="px-6 py-4 whitespace-nowrap text-sm text-center">
                                 <a href="{{ route('admin.global-invoices.show', $globalInvoice->id) }}" class="text-blue-600 hover:text-blue-900 font-medium">
                                     Voir Détails
@@ -55,7 +61,7 @@
                         </tr>
                     @empty
                         <tr>
-                            <td colspan="5" class="px-6 py-12 text-center text-sm text-gray-500">
+                            <td colspan="6" class="px-6 py-12 text-center text-sm text-gray-500">
                                 Aucune facture globale trouvée.
                             </td>
                         </tr>

--- a/resources/views/livewire/admin/invoices/global-invoice-show.blade.php
+++ b/resources/views/livewire/admin/invoices/global-invoice-show.blade.php
@@ -44,6 +44,10 @@
                                 <dt class="text-sm font-medium text-gray-500">Montant Total :</dt>
                                 <dd class="mt-1 text-sm text-gray-900 font-semibold">{{ number_format($globalInvoice->total_amount, 2) }} {{-- Devise --}}</dd>
                             </div>
+                            <div>
+                                <dt class="text-sm font-medium text-gray-500">Statut de paiement :</dt>
+                                <dd class="mt-1 text-sm text-gray-900">{{ $globalInvoice->is_paid ? 'Payée' : 'En attente' }}</dd>
+                            </div>
                         </dl>
                     </div>
                     @if($globalInvoice->notes)


### PR DESCRIPTION
## Summary
- add `is_paid` column for global invoices
- show payment status on global invoice lists and details
- initialize `is_paid` on global invoice creation

## Testing
- `composer install --no-interaction` *(fails: curl error 56 while downloading packages, response 403)*
- `php artisan test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_689dba7a5b548320b29f654d726199fa