### PR TITLE
Add payment status tracking for global invoices

### DIFF
--- a/app/Livewire/Admin/Invoices/GlobalInvoiceShow.php
+++ b/app/Livewire/Admin/Invoices/GlobalInvoiceShow.php
@@ -99,6 +99,20 @@ class GlobalInvoiceShow extends Component
         return Excel::download(new GlobalInvoiceSummaryExport($this->globalInvoice), $filename);
     }
 
+    public function markAsPaid(): void
+    {
+        $this->globalInvoice->update(['status' => 'paid']);
+        $this->globalInvoice->invoices()->update(['status' => 'paid']);
+        session()->flash('success', 'Facture globale marquée comme payée.');
+    }
+
+    public function markAsPending(): void
+    {
+        $this->globalInvoice->update(['status' => 'pending']);
+        $this->globalInvoice->invoices()->update(['status' => 'pending']);
+        session()->flash('success', 'Facture globale marquée comme en attente.');
+    }
+
     /**
      * Régénère la facture globale en se basant sur les factures partielles actives.
      * Le numéro de facture reste inchangé.

--- a/app/Models/GlobalInvoice.php
+++ b/app/Models/GlobalInvoice.php
@@ -20,6 +20,7 @@ class GlobalInvoice extends Model
         'issue_date',
         'due_date',
         'total_amount',
+        'status',
         'notes',
     ];
 

--- a/app/Services/Invoice/GlobalInvoiceService.php
+++ b/app/Services/Invoice/GlobalInvoiceService.php
@@ -118,6 +118,7 @@ class GlobalInvoiceService
                'issue_date' => Carbon::today(),
                 'due_date' => null, // À définir selon la logique métier
                 'total_amount' => $totalGlobalAmount,
+                'status' => 'pending',
                 'notes' => 'Facture globale générée automatiquement.',
             ]);
 

--- a/database/factories/GlobalInvoiceFactory.php
+++ b/database/factories/GlobalInvoiceFactory.php
@@ -4,7 +4,6 @@ namespace Database\Factories;
 
 use App\Models\GlobalInvoice;
 use App\Models\Company; // Assuming GlobalInvoice belongs to a Company
-use App\Models\User;    // Assuming GlobalInvoice might be created by a User
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 class GlobalInvoiceFactory extends Factory
@@ -16,15 +15,13 @@ class GlobalInvoiceFactory extends Factory
         // Basic definition, adjust as per your actual GlobalInvoice model schema
         return [
             'company_id' => Company::factory(),
-            'created_by_user_id' => User::factory(),
             'global_invoice_number' => $this->faker->unique()->numerify('GINV-######'),
-            'global_invoice_date' => $this->faker->date(),
             'product' => $this->faker->word(),
+            'issue_date' => $this->faker->date(),
             'due_date' => $this->faker->optional()->date(),
             'total_amount' => $this->faker->randomFloat(2, 1000, 50000),
-            'status' => $this->faker->randomElement(['draft', 'sent', 'paid', 'cancelled']),
-            'currency_code' => $this->faker->randomElement(['USD', 'EUR', 'CDF']),
-            // Add other fields as necessary based on your GlobalInvoice migration
+            'status' => $this->faker->randomElement(['pending', 'paid']),
+            'notes' => $this->faker->sentence(),
             'created_at' => now(),
             'updated_at' => now(),
         ];

--- a/database/migrations/2025_09_01_000004_add_status_to_global_invoices_table.php
+++ b/database/migrations/2025_09_01_000004_add_status_to_global_invoices_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('global_invoices', function (Blueprint $table) {
+            $table->string('status')->default('pending')->after('total_amount');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('global_invoices', function (Blueprint $table) {
+            $table->dropColumn('status');
+        });
+    }
+};

--- a/resources/views/livewire/admin/invoices/global-invoice-index.blade.php
+++ b/resources/views/livewire/admin/invoices/global-invoice-index.blade.php
@@ -26,6 +26,9 @@
                         <th scope="col" class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
                             Montant Total
                         </th>
+                        <th scope="col" class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                            Statut
+                        </th>
                         <th scope="col" class="px-6 py-3 text-center text-xs font-medium text-gray-500 uppercase tracking-wider">
                             Actions
                         </th>
@@ -46,6 +49,9 @@
                             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 text-right">
                                 {{ number_format($globalInvoice->total_amount, 2) }} {{-- Supposant que la devise est cohérente ou gérée ailleurs --}}
                             </td>
+                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                                {{ ucfirst($globalInvoice->status) }}
+                            </td>
                             <td class="px-6 py-4 whitespace-nowrap text-sm text-center">
                                 <a href="{{ route('admin.global-invoices.show', $globalInvoice->id) }}" class="text-blue-600 hover:text-blue-900 font-medium">
                                     Voir Détails
@@ -62,7 +68,7 @@
                         </tr>
                     @empty
                         <tr>
-                            <td colspan="5" class="px-6 py-12 text-center text-sm text-gray-500">
+                            <td colspan="6" class="px-6 py-12 text-center text-sm text-gray-500">
                                 Aucune facture globale trouvée.
                             </td>
                         </tr>

--- a/resources/views/livewire/admin/invoices/global-invoice-show.blade.php
+++ b/resources/views/livewire/admin/invoices/global-invoice-show.blade.php
@@ -68,6 +68,18 @@
                         <span wire:loading wire:target="exportSummary">Export...</span>
                     </button>
 
+                    @if ($globalInvoice->status === 'paid')
+                        <button wire:click="markAsPending"
+                            class="ml-2 px-4 py-2 bg-yellow-500 hover:bg-yellow-600 text-white font-semibold rounded-lg shadow-md focus:outline-none focus:ring-2 focus:ring-yellow-400 focus:ring-opacity-75 transition duration-150 ease-in-out">
+                            Marquer comme en attente
+                        </button>
+                    @else
+                        <button wire:click="markAsPaid"
+                            class="ml-2 px-4 py-2 bg-indigo-500 hover:bg-indigo-600 text-white font-semibold rounded-lg shadow-md focus:outline-none focus:ring-2 focus:ring-indigo-400 focus:ring-opacity-75 transition duration-150 ease-in-out">
+                            Marquer comme payée
+                        </button>
+                    @endif
+
                     {{-- Barre de progression lors de la génération du PDF 1 --}}
                     <div wire:loading wire:target="downloadPdf1" class="mt-2">
                         <div class="w-full bg-gray-200 rounded-full h-2.5 overflow-hidden">
@@ -138,6 +150,10 @@
                                 <dt class="text-sm font-medium text-gray-500">Montant Total :</dt>
                                 <dd class="mt-1 text-sm text-gray-900 font-semibold">
                                     {{ number_format($globalInvoice->total_amount, 2) }} {{-- Devise --}}</dd>
+                            </div>
+                            <div>
+                                <dt class="text-sm font-medium text-gray-500">Statut :</dt>
+                                <dd class="mt-1 text-sm text-gray-900">{{ ucfirst($globalInvoice->status) }}</dd>
                             </div>
                         </dl>
                     </div>


### PR DESCRIPTION
## Summary
- add status column for global invoices with migration
- show and toggle payment status in admin UI

## Testing
- `composer install --no-interaction` (fails: CONNECT tunnel failed, response 403)
- `php artisan test` (fails: vendor/autoload.php missing)


------
https://chatgpt.com/codex/tasks/task_e_689dbcc773688320ac3744f7faf69b92