### PR TITLE
Add back link to global invoice detail page

### DIFF
--- a/resources/views/livewire/admin/invoices/global-invoice-show.blade.php
+++ b/resources/views/livewire/admin/invoices/global-invoice-show.blade.php
@@ -1,5 +1,10 @@
 <div class="relative">
     <div class="container mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div class="mb-6">
+            <a href="{{ route('admin.global-invoices.index') }}" class="text-brand-500 hover:text-brand-600 font-medium">
+                &larr; Retour
+            </a>
+        </div>
         <div class="bg-white shadow-xl rounded-lg overflow-hidden">
             <div class="p-6 bg-brand-500 text-white">
                 <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4">

--- a/tests/Feature/Admin/GlobalInvoiceManagementTest.php
+++ b/tests/Feature/Admin/GlobalInvoiceManagementTest.php
@@ -226,6 +226,7 @@ class GlobalInvoiceManagementTest extends TestCase
         $response->assertSee($globalInvoice->global_invoice_number);
         $response->assertSee(number_format($globalInvoice->total_amount, 2));
         $response->assertSee(route('admin.global-invoices.edit', $globalInvoice));
+        $response->assertSee(route('admin.global-invoices.index'));
 
         foreach ($globalInvoice->globalInvoiceItems as $item) {
             $response->assertSee($item->description);


### PR DESCRIPTION
## Summary
- Add a back navigation link to the global invoice detail view
- Cover presence of index link with a feature test assertion

## Testing
- `php artisan test` *(fails: require vendor/autoload.php: No such file or directory)*
- `composer install --no-interaction` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689dd1e3596c83208fa05621b6ec936d