### PR TITLE
Affiche le titre et le numéro d'étape dans la génération de facture

### DIFF
--- a/app/Livewire/Admin/Invoices/GenerateInvoice.php
+++ b/app/Livewire/Admin/Invoices/GenerateInvoice.php
@@ -35,6 +35,7 @@ class GenerateInvoice extends Component
     public $items = [];
     public $taxes = [], $agencyFees = [], $extraFees = [], $currencies = [];
     public array $categorySteps = [];
+    public array $stepLabels = [];
     public $selectedFolder = null;
     public $generatedInvoiceLabel = null;
     public $previewInvoiceNumber = null;
@@ -85,6 +86,18 @@ class GenerateInvoice extends Component
     public function initCategorySteps(): void
     {
         $this->categorySteps = ['import_tax', 'agency_fee', 'extra_fee'];
+
+        $categoryLabels = [
+            'import_tax' => "Taxes d'import",
+            'agency_fee' => "Frais d'agence",
+            'extra_fee' => 'Frais divers',
+        ];
+
+        $this->stepLabels = [1 => 'Informations générales'];
+
+        foreach ($this->categorySteps as $index => $category) {
+            $this->stepLabels[$index + 2] = $categoryLabels[$category] ?? ucfirst(str_replace('_', ' ', $category));
+        }
     }
 
     public function updatedItems($value, $key): void

--- a/resources/views/livewire/admin/invoices/generate-invoice.blade.php
+++ b/resources/views/livewire/admin/invoices/generate-invoice.blade.php
@@ -9,10 +9,14 @@
         <div class="bg-green-100 text-green-700 px-4 py-2 rounded">{{ session('success') }}</div>
     @endif
     {{-- Barre de progression --}}
-    <div class="w-full bg-gray-200 rounded-full h-2.5 mb-6">
+    <div class="w-full bg-gray-200 rounded-full h-2.5">
         <div class="bg-indigo-600 h-2.5 rounded-full transition-all duration-300"
             style="width: {{ (100 / (count($categorySteps) + 1)) * $step }}%">
         </div>
+    </div>
+    <div class="mt-2 mb-6">
+        <div class="text-sm text-gray-600">Étape {{ $step }} / {{ count($categorySteps) + 1 }}</div>
+        <div class="text-lg font-semibold">{{ $stepLabels[$step] }}</div>
     </div>
 
     {{-- Étape 1 – Informations générales --}}


### PR DESCRIPTION
## Summary
- Affiche le numéro et le libellé de l'étape en cours sous la barre de progression de la création de facture
- Ajoute au composant Livewire un tableau `stepLabels` qui mappe chaque étape à son libellé

## Testing
- `php -l app/Livewire/Admin/Invoices/GenerateInvoice.php`
- `php artisan test` *(échoue : Failed to open stream: No such file or directory)*
- `composer install --no-interaction --no-progress` *(échoue : CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a0299e47348320895d9feae442e03a