### PR TITLE
Disable invoice buttons while loading

### DIFF
--- a/resources/views/livewire/admin/invoices/generate-invoice.blade.php
+++ b/resources/views/livewire/admin/invoices/generate-invoice.blade.php
@@ -189,8 +189,10 @@
             </div>
 
             <div class="pt-4 flex justify-end">
-                <button wire:click="nextStep" class="px-6 py-2 bg-indigo-600 text-white rounded hover:bg-indigo-700">
+                <button wire:click="nextStep" wire:loading.attr="disabled" wire:target="nextStep"
+                    class="px-6 py-2 bg-indigo-600 text-white rounded hover:bg-indigo-700">
                     Étape suivante →
+                    <span wire:loading wire:target="nextStep" class="ml-2">…spinner…</span>
                 </button>
             </div>
         </div>
@@ -332,9 +334,10 @@
                         class="px-6 py-2 bg-gray-300 text-gray-800 rounded hover:bg-gray-400">
                         ← Retour
                     </button>
-                    <button wire:click="nextStep"
+                    <button wire:click="nextStep" wire:loading.attr="disabled" wire:target="nextStep"
                         class="px-6 py-2 bg-indigo-600 text-white font-semibold rounded hover:bg-indigo-700">
                         Étape suivante →
+                        <span wire:loading wire:target="nextStep" class="ml-2">…spinner…</span>
                     </button>
                 </div>
             </div>
@@ -380,9 +383,10 @@
                     class="px-6 py-2 bg-gray-300 text-gray-800 rounded hover:bg-gray-400">
                     ← Retour
                 </button>
-                <button wire:click="save"
+                <button wire:click="save" wire:loading.attr="disabled" wire:target="save"
                     class="px-6 py-2 bg-green-600 text-white font-semibold rounded hover:bg-green-700">
                     💾 Enregistrer la facture
+                    <span wire:loading wire:target="save" class="ml-2">…spinner…</span>
                 </button>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- Disable Next Step and Save buttons during Livewire actions
- Show loading indicator on buttons to prevent multiple clicks

## Testing
- `composer install` *(fails: curl error 56, CONNECT tunnel failed 403)*
- `./vendor/bin/pest` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a02ddca23c83209b764d1ec3b052b1