### PR TITLE
Fix missing labels and amount key in invoice summary

### DIFF
--- a/app/Livewire/Admin/Invoices/GenerateInvoice.php
+++ b/app/Livewire/Admin/Invoices/GenerateInvoice.php
@@ -128,6 +128,22 @@ class GenerateInvoice extends Component
                     $item['amount_cdf'] = round($localAmount, 2);
                 }
             }
+        } elseif (preg_match('/^(\d+)\.(tax_id|agency_fee_id|extra_fee_id)$/', $key, $matches)) {
+            $index = (int)$matches[1];
+            $field = $matches[2];
+            $item = &$this->items[$index];
+
+            switch ($field) {
+                case 'tax_id':
+                    $item['label'] = Tax::find($value)?->label ?? '';
+                    break;
+                case 'agency_fee_id':
+                    $item['label'] = AgencyFee::find($value)?->label ?? '';
+                    break;
+                case 'extra_fee_id':
+                    $item['label'] = ExtraFee::find($value)?->label ?? '';
+                    break;
+            }
         }
     }
 
@@ -149,6 +165,7 @@ class GenerateInvoice extends Component
             'exchange_rate' => $this->exchange_rate,
             'amount_local' => 0,
             'amount_usd' => 0.00,
+            'amount_cdf' => 0,
             'converted_amount' => 0,
             'tax_id' => null,
             'agency_fee_id' => null,

--- a/resources/views/livewire/admin/invoices/generate-invoice.blade.php
+++ b/resources/views/livewire/admin/invoices/generate-invoice.blade.php
@@ -258,9 +258,9 @@
                         <tbody class="bg-white divide-y divide-gray-200">
                             @forelse ($items as $item)
                                 <tr>
-                                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{{ $item['label'] }}</td>
-                                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 text-right">{{ number_format($item['amount_usd'], 2, '.', ' ') }}</td>
-                                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 text-right">{{ number_format($item['amount_cdf'], 2, '.', ' ') }}</td>
+                                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">{{ $item['label'] ?? '' }}</td>
+                                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 text-right">{{ number_format($item['amount_usd'] ?? 0, 2, '.', ' ') }}</td>
+                                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 text-right">{{ number_format($item['amount_cdf'] ?? 0, 2, '.', ' ') }}</td>
                                 </tr>
                             @empty
                                 <tr>


### PR DESCRIPTION
## Summary
- Ensure invoice items default to `amount_cdf` and update labels when selecting fees or taxes
- Guard summary display against missing data to avoid undefined index errors

## Testing
- `php -l app/Livewire/Admin/Invoices/GenerateInvoice.php`
- `composer install --no-interaction --no-progress` *(fails: connect tunnel 403)*
- `./vendor/bin/pest` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a0640ad24883208b76208d40fc2035